### PR TITLE
Redesign homepage and dashboard UI/UX

### DIFF
--- a/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/index.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/index.html.heex
@@ -8,6 +8,82 @@
   </div>
 <% end %>
 
+<!-- Quick Start Guide (first thing users see) -->
+<section class="mb-8">
+  <div class="bg-white rounded-2xl shadow-sm dark:bg-gray-800 border border-gray-100 dark:border-gray-700 overflow-hidden" x-data="collapse()">
+    <button
+      class="flex items-center justify-between w-full px-6 py-4 text-left"
+      aria-controls="quickstart-collapse"
+      aria-expanded="false"
+      x-spread="trigger"
+    >
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 text-indigo-600 dark:text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+        </svg>
+        <span class="font-bold text-gray-900 dark:text-white">Quick Start Guide</span>
+      </div>
+      <svg
+        x-bind:class="{ 'rotate-180': open }"
+        class="transition transform h-5 w-5 text-gray-400 dark:text-gray-500"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="6 9 12 15 18 9"></polyline>
+      </svg>
+    </button>
+    <div id="quickstart-collapse" x-spread="collapse" x-cloak class="border-t border-gray-100 dark:border-gray-700">
+      <ol class="px-6 py-4 space-y-3">
+        <li class="flex gap-3 items-start">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">1</span>
+          <a
+            target="_blank"
+            href="https://dashboard.twitch.tv/extensions/h1ekceo16erc49snp0sine3k9ccbh9"
+            class="text-sm text-indigo-600 hover:underline dark:text-indigo-400"
+          >
+            Install the Twitch Extension on your channel (if streaming on Twitch)
+          </a>
+        </li>
+        <li class="flex gap-3 items-start">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">2</span>
+          <%= link "Set your spoken language in Caption Settings", to: ~p"/users/caption-settings", class: "text-sm text-indigo-600 hover:underline dark:text-indigo-400" %>
+        </li>
+        <li class="flex gap-3 items-start">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">3</span>
+          <span class="text-sm text-gray-700 dark:text-gray-300">Click "Click to Start Captions" below when you're ready to go live</span>
+        </li>
+        <li class="flex gap-3 items-start">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">4</span>
+          <span class="text-sm text-gray-700 dark:text-gray-300">Allow microphone access when prompted by your browser</span>
+        </li>
+        <li class="flex gap-3 items-start">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">5</span>
+          <span class="text-sm text-gray-700 dark:text-gray-300">Confirm the correct microphone is selected in your browser settings</span>
+        </li>
+        <li class="flex gap-3 items-start pt-1">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6">
+            <svg class="w-5 h-5 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </span>
+          <a
+            target="_blank"
+            href="https://talk2megooseman.notion.site/stream-cc-faq"
+            class="text-sm text-gray-500 hover:text-indigo-600 hover:underline dark:text-gray-400 dark:hover:text-indigo-400"
+          >
+            Full documentation and FAQ
+          </a>
+        </li>
+      </ol>
+    </div>
+  </div>
+</section>
+
 <!-- Primary Action: Start Captions -->
 <section class="mb-8">
   <div class="overflow-hidden bg-gradient-to-br from-indigo-600 to-purple-700 rounded-2xl shadow-lg dark:from-indigo-700 dark:to-purple-800">
@@ -261,82 +337,6 @@
       <div x-spread="collapse" x-cloak id="translation-toggle" class="border-t border-gray-100 dark:border-gray-700">
         <ul data-translations-target="translationsList" class="px-4 py-2 divide-y divide-gray-100 dark:divide-gray-700"></ul>
       </div>
-    </div>
-  </div>
-</section>
-
-<!-- Quick Start Guide -->
-<section class="mb-8">
-  <div class="bg-white rounded-2xl shadow-sm dark:bg-gray-800 border border-gray-100 dark:border-gray-700 overflow-hidden" x-data="collapse()">
-    <button
-      class="flex items-center justify-between w-full px-6 py-4 text-left"
-      aria-controls="quickstart-collapse"
-      aria-expanded="false"
-      x-spread="trigger"
-    >
-      <div class="flex items-center gap-2">
-        <svg class="w-5 h-5 text-indigo-600 dark:text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-        </svg>
-        <span class="font-bold text-gray-900 dark:text-white">Quick Start Guide</span>
-      </div>
-      <svg
-        x-bind:class="{ 'rotate-180': open }"
-        class="transition transform h-5 w-5 text-gray-400"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <polyline points="6 9 12 15 18 9"></polyline>
-      </svg>
-    </button>
-    <div id="quickstart-collapse" x-spread="collapse" x-cloak class="border-t border-gray-100 dark:border-gray-700">
-      <ol class="px-6 py-4 space-y-3">
-        <li class="flex gap-3">
-          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">1</span>
-          <a
-            target="_blank"
-            href="https://dashboard.twitch.tv/extensions/h1ekceo16erc49snp0sine3k9ccbh9"
-            class="text-sm text-indigo-600 hover:underline dark:text-indigo-400"
-          >
-            Install the Twitch Extension on your channel (if streaming on Twitch)
-          </a>
-        </li>
-        <li class="flex gap-3">
-          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">2</span>
-          <%= link "Set your spoken language in Caption Settings", to: ~p"/users/caption-settings", class: "text-sm text-indigo-600 hover:underline dark:text-indigo-400" %>
-        </li>
-        <li class="flex gap-3">
-          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">3</span>
-          <span class="text-sm text-gray-700 dark:text-gray-300">Click "Click to Start Captions" above when you're ready to go live</span>
-        </li>
-        <li class="flex gap-3">
-          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">4</span>
-          <span class="text-sm text-gray-700 dark:text-gray-300">Allow microphone access when prompted by your browser</span>
-        </li>
-        <li class="flex gap-3">
-          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">5</span>
-          <span class="text-sm text-gray-700 dark:text-gray-300">Confirm the correct microphone is selected in your browser settings</span>
-        </li>
-        <li class="flex gap-3 pt-1">
-          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6">
-            <svg class="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-            </svg>
-          </span>
-          <a
-            target="_blank"
-            href="https://talk2megooseman.notion.site/stream-cc-faq"
-            class="text-sm text-gray-500 hover:text-indigo-600 hover:underline dark:text-gray-400 dark:hover:text-indigo-400"
-          >
-            Full documentation and FAQ →
-          </a>
-        </li>
-      </ol>
     </div>
   </div>
 </section>

--- a/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/index.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/index.html.heex
@@ -1,369 +1,342 @@
-<section class="px-4 pb-12 mx-auto max-w-7xl">
-  <div class="grid grid-cols-1 gap-5 lg:grid-cols-3">
-    <!-- Twitch Indicator -->
-    <%= if @twitch_enabled do %>
-      <.twitch_enabled_indicator settings={@stream_settings} />
-    <% else %>
-      <.twitch_disabled_indicator settings={@stream_settings} />
-    <% end %>
-    <!-- Zoom Indicator -->
-    <div>
-      <div class="p-5 card shadow dark:bg-gray-800" data-controller="zoom">
-        <div class="flex flex-row items-center">
-          <div
-            data-zoom-target="errorMarker"
-            class="hidden flex items-center justify-center w-10 h-10 text-red-700 bg-red-100 rounded"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              class="flex-none w-5 h-5"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                clip-rule="evenodd"
-              />
-            </svg>
-          </div>
-          <div class="ml-3">
-            <h2 class="mb-1 text-lg font-bold leading-none text-gray-900 whitespace-normal">
-              Zoom Meeting Captions
-            </h2>
-            <p class="text-sm leading-none text-gray-600">Send captions to your Zoom meeting.</p>
-          </div>
-          <div class="flex-grow text-right">
-            <div data-action="click->zoom#enable">
-              <div data-zoom-target="offButton">
-                <%= _switch_off(assigns) %>
-              </div>
-              <div class="hidden" data-zoom-target="onButton">
-                <%= _switch_on(assigns) %>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="flex flex-row items-center mt-2">
-          <span class="flex-auto p-1">
-            <label class="block text-xs mb-1" for="zoom-url">Zoom Captions URL</label>
-            <input
-              class="form-input form-input-sm"
-              id="zoom-url"
-              placeholder="https://..."
-              data-action="zoom#onUrlChange"
-            />
-          </span>
-        </div>
-        <div
-          data-zoom-target="errorMessage"
-          class="alert mt-2 hidden text-red-700 bg-red-100"
-          role="alert"
-        >
-        </div>
-      </div>
-    </div>
-    <!-- OBS Indicator -->
-    <div>
-      <div
-        class="p-5 card shadow dark:bg-gray-800"
-        data-controller="obs"
-        data-action="captions:payload@window->obs#onCaptionsReceived"
-      >
-        <div class="flex flex-row items-center">
-          <!-- X svg -->
-          <div
-            data-obs-target="errorMarker"
-            class="hidden flex items-center justify-center w-10 h-10 text-red-700 bg-red-100 rounded"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              class="flex-none w-5 h-5"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                clip-rule="evenodd"
-              />
-            </svg>
-          </div>
-          <div class="ml-3">
-            <h2 class="mb-1 text-lg font-bold leading-none text-gray-900 whitespace-normal">
-              OBS Websocket
-            </h2>
-            <p class="text-sm leading-none text-gray-600">Send captions directly to OBS</p>
-          </div>
-          <div class="flex-grow text-right">
-            <div data-action="click->obs#connectToOBS">
-              <div data-obs-target="offButton">
-                <%= _switch_off(assigns) %>
-              </div>
-              <div class="hidden" data-obs-target="onButton">
-                <%= _switch_on(assigns) %>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="flex flex-row items-center mt-2">
-          <span class="flex-auto p-1">
-            <label class="block text-xs mb-1" for="port">Port</label>
-            <input
-              class="form-input form-input-sm"
-              id="part"
-              value="4455"
-              data-action="obs#onPortChange"
-            />
-          </span>
-          <span class="flex-auto p-1">
-            <label class="block text-xs mb-1" for="password">Password</label>
-            <input
-              type="password"
-              class="form-input form-input-sm"
-              placeholder="Password69"
-              id="password"
-              data-action="obs#onPasswordChange"
-            />
-          </span>
-        </div>
-        <div
-          data-obs-target="errorMessage"
-          class="alert mt-2 hidden text-red-700 bg-red-100"
-          role="alert"
-        >
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-<!-- Translation Sections -->
-<section class="px-4 pb-12">
-  <div class="card shadow dark:bg-gray-800">
-    <div class="card-header">
-      <h5 class="card-title">
-        Twitch Translation Information
-      </h5>
-      <a href="https://www.notion.so/talk2megooseman/How-Translations-Work-d6b58b0356de41a5aa5f73cf908a7531">
-        <span class="flex flex-row">
-          <svg
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            class="flex-none w-6 h-6 mr-1 text-gray-700"
-            aria-hidden="true"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-            >
-            </path>
-          </svg>
-          Help
-        </span>
-      </a>
-    </div>
-    <div
-      data-controller="translations"
-      data-action="captions:payload@window->translations#onCaptionsReceived"
-    >
-      <div class="card-header divide-x text-center">
-        <div class="flex-1 p-2">
-          <h5 class="text-sm font-bold text-gray-900" data-translations-target="translationStatus">
-            <%= display_translation_status(@translation_active) %>
-          </h5>
-          <p class="text-sm font-medium leading-none text-gray-600">Translations Status</p>
-        </div>
-        <div class="flex-1 p-2">
-          <h5 class="text-sm font-bold text-gray-900" data-translations-target="bitsBalance">
-            <%= @bits_balance %>
-          </h5>
-          <p class="text-sm font-medium leading-none text-gray-600">Translation Credit Balance</p>
-        </div>
-        <div class="flex-1 p-2">
-          <h5 class="text-sm font-bold text-gray-900">
-            <%= if Enum.empty?(@translate_languages) do %>
-              <.link navigate={~p"/users/caption-settings"} class="text-red-500 mx-5">
-                You must select a translation language in your Caption Settings to activate translations
-              </.link>
-            <% else %>
-              <%= Map.values(@translate_languages) |> Enum.join(", ") %>
-            <% end %>
-          </h5>
-          <p class="text-sm font-medium leading-none text-gray-600">
-            Selected Translation Language
-          </p>
-        </div>
-        <div class="flex-1 p-2">
-          <p class="text-sm font-medium leading-none text-gray-600">
-            500 credits are required for to activate translations
-            for 24 hours
-          </p>
-        </div>
-      </div>
-      <div data-translations-target="displayTranslations" class="hidden" x-data="collapse()">
-        <div
-          x-spread="trigger"
-          class="p-3 flex justify-between items-center bg-green-100"
-          role="button"
-          aria-controls="translation-toggle"
-          aria-expanded="false"
-        >
-          Click here to toggle viewing translated captions
-          <svg
-            x-bind:class="{ 'rotate-180': open }"
-            class="transition transform h-4 w-4 flex-none"
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <polyline points="6 9 12 15 18 9"></polyline>
-          </svg>
-        </div>
-        <div x-spread="collapse" x-cloak class="" id="translation-toggle">
-          <ul data-translations-target="translationsList" class="list"></ul>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-<!-- Instructions -->
-<section class="px-4 pb-4">
-  <div x-data="collapse()">
-    <button
-      class="btn btn-primary"
-      aria-controls="basicCollapse"
-      aria-expanded="false"
-      x-spread="trigger"
-    >
-      Quick Start
-      Instructions
-    </button>
-    <div class="grid gap-3 bg-white" id="basicCollapse" x-spread="collapse" x-cloak>
-      <ul class="list">
-        <li class="list-item">
-          <a
-            target="_blank"
-            href="https://dashboard.twitch.tv/extensions/h1ekceo16erc49snp0sine3k9ccbh9"
-            class="text-blue-600"
-          >
-            1. Install
-            the Twitch Extension, if you're streaming on Twitch
-          </a>
-        </li>
-        <li class="list-item">
-          <%= link("2. Update your language in your caption settings",
-            to: ~p"/users/caption-settings",
-            class: "text-blue-600"
-          ) %>
-        </li>
-        <li class="list-item">
-          3. When your're ready to start sending captions, click "Click to Start Captions"
-        </li>
-        <li class="list-item">4. Allow microphone permissions if prompted next to address bar</li>
-        <li class="list-item">5. Double check you have the correct microphone selected.</li>
-        <li class="list-item">
-          <a
-            target="_blank"
-            class="text-blue-600"
-            href="https://talk2megooseman.notion.site/stream-cc-faq"
-          >
-            Click here for more details instructions or additional help.
-          </a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</section>
-<!-- Captions Sections -->
+<!-- Announcement Banner (if active) -->
 <%= if @announcement.display do %>
-  <div class="alert bg-primary-light text-primary text-left" role="alert">
-    <div>
-      <%= raw(@announcement.message) %>
-    </div>
+  <div class="flex items-start gap-3 px-4 py-3 mb-6 text-sm text-blue-800 bg-blue-50 border border-blue-200 rounded-xl dark:bg-blue-900/30 dark:border-blue-700 dark:text-blue-200" role="alert">
+    <svg class="flex-shrink-0 w-5 h-5 mt-0.5 text-blue-600 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+    </svg>
+    <div><%= raw(@announcement.message) %></div>
   </div>
 <% end %>
-<section class="px-4 pb-12">
-  <div class="card shadow dark:bg-gray-800">
-    <div class="card-header">
-      <h5 class="card-title">
-        Your Captions
-      </h5>
-      <div class="flex items-center">
-        <span>Selected Language: <%= @stream_settings.language %></span>
-        <.link navigate={~p"/users/caption-settings"} class="flex btn btn-outline-primary mx-5">
-          <svg
-            class="shrink-0 w-5 h-5 mr-2 text-gray-400 transition group-hover:text-gray-300"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
-              clip-rule="evenodd"
-            />
-          </svg>
-          <span>Caption Settings</span>
-        </.link>
-        <a href="https://talk2megooseman.notion.site/stream-cc-faq">
-          <span class="flex flex-row">
-            <svg
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              class="flex-none w-6 h-6 mr-1 text-gray-700"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              >
-              </path>
+
+<!-- Primary Action: Start Captions -->
+<section class="mb-8">
+  <div class="overflow-hidden bg-gradient-to-br from-indigo-600 to-purple-700 rounded-2xl shadow-lg dark:from-indigo-700 dark:to-purple-800">
+    <div class="p-6 md:p-8">
+      <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 class="mb-1 text-2xl font-extrabold text-white">Your Captions</h1>
+          <p class="text-indigo-200">
+            Speaking in:
+            <span class="font-semibold text-white"><%= @stream_settings.language %></span>
+          </p>
+        </div>
+        <div class="flex flex-wrap items-center gap-3">
+          <.link navigate={~p"/users/caption-settings"} class="inline-flex items-center px-4 py-2 text-sm font-semibold text-indigo-100 bg-white/10 rounded-lg hover:bg-white/20 transition-colors border border-white/20">
+            <svg class="w-4 h-4 mr-1.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
             </svg>
-            Help
-          </span>
-        </a>
+            Caption Settings
+          </.link>
+          <a
+            href="https://talk2megooseman.notion.site/stream-cc-faq"
+            target="_blank"
+            class="inline-flex items-center px-4 py-2 text-sm font-semibold text-indigo-100 bg-white/10 rounded-lg hover:bg-white/20 transition-colors border border-white/20"
+          >
+            <svg class="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Help / FAQ
+          </a>
+        </div>
       </div>
-    </div>
-    <div id="caption-actions">
+
       <div
+        id="caption-actions"
+        class="mt-6"
         data-controller="captions"
         data-captions-language-value={@stream_settings.language}
         data-action="twitch:state@window->captions#onTwitchChange zoom:state@window->captions#onZoomChange"
       >
-        <div class="p-4">
+        <!-- Caption output preview -->
+        <div class="p-4 mb-4 bg-black/20 rounded-xl min-h-16">
           <div class="space-y-2" data-captions-target="outputOutline">
-            <div class="w-9/12 h-4 bg-gray-200 rounded animate-pulse"></div>
-            <div class="w-11/12 h-4 bg-gray-200 rounded animate-pulse"></div>
-            <div class="w-8/12 h-4 bg-gray-200 rounded animate-pulse"></div>
+            <div class="w-9/12 h-3 bg-white/20 rounded animate-pulse"></div>
+            <div class="w-11/12 h-3 bg-white/20 rounded animate-pulse"></div>
+            <div class="w-8/12 h-3 bg-white/20 rounded animate-pulse"></div>
           </div>
-          <div class="space-y-2 hidden" data-captions-target="realOutput">
-            <p class="uppercase" data-captions-target="finalOutput"></p>
-            <p class="uppercase" data-captions-target="interimOutput"></p>
+          <div class="space-y-1 hidden" data-captions-target="realOutput">
+            <p class="text-white uppercase font-medium" data-captions-target="finalOutput"></p>
+            <p class="text-indigo-200 uppercase text-sm" data-captions-target="interimOutput"></p>
           </div>
-          <div class=" text-red-900" data-captions-target="warning"></div>
+          <div class="text-red-300 text-sm" data-captions-target="warning"></div>
         </div>
         <button
-          class="w-full btn btn-primary"
+          class="w-full py-4 text-lg font-bold text-indigo-700 bg-white rounded-xl hover:bg-indigo-50 transition-colors shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
           data-captions-target="start"
           data-action="click->captions#startCaptions"
           disabled
         >
           Click to Start Captions
         </button>
-        <div></div>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- Integrations Row -->
+<section class="mb-8">
+  <h2 class="mb-4 text-sm font-semibold tracking-wider text-gray-500 uppercase dark:text-gray-400">
+    Integrations
+  </h2>
+  <div class="grid grid-cols-1 gap-4 lg:grid-cols-3">
+    <!-- Twitch Integration -->
+    <%= if @twitch_enabled do %>
+      <.twitch_enabled_indicator settings={@stream_settings} />
+    <% else %>
+      <.twitch_disabled_indicator settings={@stream_settings} />
+    <% end %>
+
+    <!-- Zoom Integration -->
+    <div class="p-5 bg-white rounded-2xl shadow-sm dark:bg-gray-800 border border-gray-100 dark:border-gray-700" data-controller="zoom">
+      <div class="flex items-start justify-between mb-4">
+        <div class="flex items-center gap-3">
+          <div class="flex items-center justify-center w-10 h-10 bg-blue-100 dark:bg-blue-900/40 rounded-xl">
+            <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M24 12c0 6.627-5.373 12-12 12S0 18.627 0 12 5.373 0 12 0s12 5.373 12 12zm-4.5-1.5h-15v3h15v-3z"/>
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-gray-900 dark:text-white">Zoom Meeting</h3>
+            <p class="text-xs text-gray-500 dark:text-gray-400">Send captions to Zoom</p>
+          </div>
+        </div>
+        <div data-action="click->zoom#enable">
+          <div data-zoom-target="offButton"><%= _switch_off(assigns) %></div>
+          <div class="hidden" data-zoom-target="onButton"><%= _switch_on(assigns) %></div>
+        </div>
+      </div>
+      <div
+        data-zoom-target="errorMarker"
+        class="hidden flex items-center gap-2 px-3 py-2 mb-3 text-xs font-medium text-red-700 bg-red-100 rounded-lg dark:bg-red-900/30 dark:text-red-400"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="flex-none w-4 h-4">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+        </svg>
+        Error connecting
+      </div>
+      <div>
+        <label class="block mb-1 text-xs font-medium text-gray-500 dark:text-gray-400" for="zoom-url">Zoom Captions URL</label>
+        <input
+          class="w-full px-3 py-2 text-sm bg-gray-50 border border-gray-200 rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+          id="zoom-url"
+          placeholder="https://..."
+          data-action="zoom#onUrlChange"
+        />
+      </div>
+      <div data-zoom-target="errorMessage" class="hidden mt-2 p-2 text-xs text-red-700 bg-red-100 rounded-lg dark:bg-red-900/30 dark:text-red-400" role="alert"></div>
+    </div>
+
+    <!-- OBS Integration -->
+    <div
+      class="p-5 bg-white rounded-2xl shadow-sm dark:bg-gray-800 border border-gray-100 dark:border-gray-700"
+      data-controller="obs"
+      data-action="captions:payload@window->obs#onCaptionsReceived"
+    >
+      <div class="flex items-start justify-between mb-4">
+        <div class="flex items-center gap-3">
+          <div class="flex items-center justify-center w-10 h-10 bg-gray-100 dark:bg-gray-700 rounded-xl">
+            <svg class="w-5 h-5 text-gray-700 dark:text-gray-300" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14H9V8h2v8zm4 0h-2V8h2v8z"/>
+            </svg>
+          </div>
+          <div>
+            <h3 class="font-bold text-gray-900 dark:text-white">OBS Websocket</h3>
+            <p class="text-xs text-gray-500 dark:text-gray-400">Send captions to OBS Studio</p>
+          </div>
+        </div>
+        <div data-action="click->obs#connectToOBS">
+          <div data-obs-target="offButton"><%= _switch_off(assigns) %></div>
+          <div class="hidden" data-obs-target="onButton"><%= _switch_on(assigns) %></div>
+        </div>
+      </div>
+      <div
+        data-obs-target="errorMarker"
+        class="hidden flex items-center gap-2 px-3 py-2 mb-3 text-xs font-medium text-red-700 bg-red-100 rounded-lg dark:bg-red-900/30 dark:text-red-400"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="flex-none w-4 h-4">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+        </svg>
+        Error connecting
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <label class="block mb-1 text-xs font-medium text-gray-500 dark:text-gray-400" for="port">Port</label>
+          <input
+            class="w-full px-3 py-2 text-sm bg-gray-50 border border-gray-200 rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            id="port"
+            value="4455"
+            data-action="obs#onPortChange"
+          />
+        </div>
+        <div>
+          <label class="block mb-1 text-xs font-medium text-gray-500 dark:text-gray-400" for="password">Password</label>
+          <input
+            type="password"
+            class="w-full px-3 py-2 text-sm bg-gray-50 border border-gray-200 rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            placeholder="Optional"
+            id="password"
+            data-action="obs#onPasswordChange"
+          />
+        </div>
+      </div>
+      <div data-obs-target="errorMessage" class="hidden mt-2 p-2 text-xs text-red-700 bg-red-100 rounded-lg dark:bg-red-900/30 dark:text-red-400" role="alert"></div>
+    </div>
+  </div>
+</section>
+
+<!-- Translation Info -->
+<section class="mb-8">
+  <div
+    class="bg-white rounded-2xl shadow-sm dark:bg-gray-800 border border-gray-100 dark:border-gray-700 overflow-hidden"
+    data-controller="translations"
+    data-action="captions:payload@window->translations#onCaptionsReceived"
+  >
+    <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+      <h2 class="font-bold text-gray-900 dark:text-white">Twitch Translations</h2>
+      <a
+        href="https://www.notion.so/talk2megooseman/How-Translations-Work-d6b58b0356de41a5aa5f73cf908a7531"
+        target="_blank"
+        class="inline-flex items-center text-xs font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+      >
+        <svg class="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        How it works
+      </a>
+    </div>
+    <div class="grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-y-0 sm:divide-x divide-gray-100 dark:divide-gray-700">
+      <div class="px-6 py-4">
+        <p class="mb-1 text-xs font-medium text-gray-500 uppercase dark:text-gray-400">Status</p>
+        <p class="text-lg font-bold text-gray-900 dark:text-white" data-translations-target="translationStatus">
+          <%= display_translation_status(@translation_active) %>
+        </p>
+      </div>
+      <div class="px-6 py-4">
+        <p class="mb-1 text-xs font-medium text-gray-500 uppercase dark:text-gray-400">Credit Balance</p>
+        <p class="text-lg font-bold text-gray-900 dark:text-white" data-translations-target="bitsBalance">
+          <%= @bits_balance %>
+        </p>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">500 credits = 24 hrs of translations</p>
+      </div>
+      <div class="px-6 py-4">
+        <p class="mb-1 text-xs font-medium text-gray-500 uppercase dark:text-gray-400">Translation Language</p>
+        <%= if Enum.empty?(@translate_languages) do %>
+          <.link navigate={~p"/users/caption-settings"} class="inline-flex items-center text-sm font-semibold text-amber-600 hover:text-amber-500 dark:text-amber-400">
+            <svg class="w-4 h-4 mr-1 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            Select a language in Settings
+          </.link>
+        <% else %>
+          <p class="text-lg font-bold text-gray-900 dark:text-white">
+            <%= Map.values(@translate_languages) |> Enum.join(", ") %>
+          </p>
+        <% end %>
+      </div>
+    </div>
+
+    <div data-translations-target="displayTranslations" class="hidden" x-data="collapse()">
+      <div
+        x-spread="trigger"
+        class="flex items-center justify-between px-6 py-3 bg-green-50 dark:bg-green-900/20 border-t border-green-100 dark:border-green-800 cursor-pointer"
+        role="button"
+        aria-controls="translation-toggle"
+        aria-expanded="false"
+      >
+        <span class="text-sm font-medium text-green-700 dark:text-green-400">View translated captions</span>
+        <svg
+          x-bind:class="{ 'rotate-180': open }"
+          class="transition transform h-4 w-4 flex-none text-green-600 dark:text-green-400"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+      </div>
+      <div x-spread="collapse" x-cloak id="translation-toggle" class="border-t border-gray-100 dark:border-gray-700">
+        <ul data-translations-target="translationsList" class="px-4 py-2 divide-y divide-gray-100 dark:divide-gray-700"></ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Quick Start Guide -->
+<section class="mb-8">
+  <div class="bg-white rounded-2xl shadow-sm dark:bg-gray-800 border border-gray-100 dark:border-gray-700 overflow-hidden" x-data="collapse()">
+    <button
+      class="flex items-center justify-between w-full px-6 py-4 text-left"
+      aria-controls="quickstart-collapse"
+      aria-expanded="false"
+      x-spread="trigger"
+    >
+      <div class="flex items-center gap-2">
+        <svg class="w-5 h-5 text-indigo-600 dark:text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+        </svg>
+        <span class="font-bold text-gray-900 dark:text-white">Quick Start Guide</span>
+      </div>
+      <svg
+        x-bind:class="{ 'rotate-180': open }"
+        class="transition transform h-5 w-5 text-gray-400"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="6 9 12 15 18 9"></polyline>
+      </svg>
+    </button>
+    <div id="quickstart-collapse" x-spread="collapse" x-cloak class="border-t border-gray-100 dark:border-gray-700">
+      <ol class="px-6 py-4 space-y-3">
+        <li class="flex gap-3">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">1</span>
+          <a
+            target="_blank"
+            href="https://dashboard.twitch.tv/extensions/h1ekceo16erc49snp0sine3k9ccbh9"
+            class="text-sm text-indigo-600 hover:underline dark:text-indigo-400"
+          >
+            Install the Twitch Extension on your channel (if streaming on Twitch)
+          </a>
+        </li>
+        <li class="flex gap-3">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">2</span>
+          <%= link "Set your spoken language in Caption Settings", to: ~p"/users/caption-settings", class: "text-sm text-indigo-600 hover:underline dark:text-indigo-400" %>
+        </li>
+        <li class="flex gap-3">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">3</span>
+          <span class="text-sm text-gray-700 dark:text-gray-300">Click "Click to Start Captions" above when you're ready to go live</span>
+        </li>
+        <li class="flex gap-3">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">4</span>
+          <span class="text-sm text-gray-700 dark:text-gray-300">Allow microphone access when prompted by your browser</span>
+        </li>
+        <li class="flex gap-3">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6 text-xs font-bold text-white bg-indigo-600 rounded-full">5</span>
+          <span class="text-sm text-gray-700 dark:text-gray-300">Confirm the correct microphone is selected in your browser settings</span>
+        </li>
+        <li class="flex gap-3 pt-1">
+          <span class="flex-shrink-0 flex items-center justify-center w-6 h-6">
+            <svg class="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </span>
+          <a
+            target="_blank"
+            href="https://talk2megooseman.notion.site/stream-cc-faq"
+            class="text-sm text-gray-500 hover:text-indigo-600 hover:underline dark:text-gray-400 dark:hover:text-indigo-400"
+          >
+            Full documentation and FAQ →
+          </a>
+        </li>
+      </ol>
     </div>
   </div>
 </section>

--- a/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/indicators/twitch_disabled_indicator.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/indicators/twitch_disabled_indicator.html.heex
@@ -1,44 +1,25 @@
-<div>
-  <div class="flex-row items-center p-5 card shadow dark:bg-gray-800">
-    <div class="flex items-center justify-center w-14 h-14 text-green-700 bg-green-100 rounded">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="flex-none w-5 h-5">
-        <path fill-rule="evenodd"
-          d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-          clip-rule="evenodd" />
+<div class="p-5 bg-white rounded-2xl shadow-sm dark:bg-gray-800 border border-gray-100 dark:border-gray-700">
+  <div class="flex items-start gap-3 mb-4">
+    <div class="flex items-center justify-center w-10 h-10 bg-purple-100 dark:bg-purple-900/40 rounded-xl">
+      <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z"/>
       </svg>
     </div>
-    <div class="mx-3">
-      <h2 class="mb-1 text-lg font-bold leading-none text-gray-900 whitespace-normal">Twitch Extension Captions</h2>
-      <p class="text-sm leading-none text-gray-600">Please connect your Twitch account to enable this feature.</p>
-    </div>
-    <div class="flex-grow text-right">
-      <a href="/auth/twitch" class="w-full py-3 btn btn-icon btn-primary">
-        <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-          x="0px" y="0px" viewBox="0 0 2400 2800" style="enable-background:new 0 0 2400 2800;" xml:space="preserve">
-          <style type="text/css">
-            .st0 {
-              fill: #FFFFFF;
-            }
-
-            .st1 {
-              fill: #9146FF;
-            }
-          </style>
-          <title>Twitch Glitch</title>
-          <g>
-            <polygon class="st0"
-              points="2200,1300 1800,1700 1400,1700 1050,2050 1050,1700 600,1700 600,200 2200,200 	" />
-            <g>
-              <g id="Layer_1-2">
-                <path class="st1" d="M500,0L0,500v1800h600v500l500-500h400l900-900V0H500z M2200,1300l-400,400h-400l-350,350v-350H600V200h1600
-      V1300z" />
-                <rect x="1700" y="550" class="st1" width="200" height="600" />
-                <rect x="1150" y="550" class="st1" width="200" height="600" />
-              </g>
-            </g>
-          </g>
-        </svg>
-      </a>
+    <div>
+      <h3 class="font-bold text-gray-900 dark:text-white">Twitch Extension</h3>
+      <p class="text-xs text-gray-500 dark:text-gray-400">Connect Twitch to enable</p>
     </div>
   </div>
+  <p class="mb-3 text-sm text-gray-600 dark:text-gray-400">
+    Link your Twitch account to send live captions to your channel's extension.
+  </p>
+  <a
+    href="/auth/twitch"
+    class="inline-flex items-center justify-center w-full px-4 py-2 text-sm font-semibold text-white bg-purple-600 rounded-lg hover:bg-purple-500 transition-colors"
+  >
+    <svg class="w-4 h-4 mr-2" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z"/>
+    </svg>
+    Connect with Twitch
+  </a>
 </div>

--- a/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/indicators/twitch_enabled_indicator.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/indicators/twitch_enabled_indicator.html.heex
@@ -1,30 +1,31 @@
 <div id="twitch-enabled-indicator" phx-update="ignore">
-  <div class="p-5 card shadow dark:bg-gray-800" data-controller="twitch">
-    <div class="flex flex-row items-center">
-      <div data-twitch-target="errorMarker"
-        class="hidden flex items-center justify-center w-10 h-10 text-red-700 bg-red-100 rounded">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="flex-none w-5 h-5">
-          <path fill-rule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-            clip-rule="evenodd" />
-        </svg>
-      </div>
-      <div class="ml-3">
-        <h2 class="mb-1 text-lg font-bold leading-none text-gray-900 whitespace-normal">Twitch Extension Captions
-        </h2>
-        <p class="text-sm leading-none text-gray-600">Available and ready to turn on</p>
-      </div>
-      <div class="flex-grow text-right">
-        <div data-action="mousedown->twitch#toggleOn">
-          <div class="hidden" data-twitch-target="offSwitch">
-            <%= _switch_off(assigns) %>
-          </div>
-          <div data-twitch-target="onSwitch">
-            <%= _switch_on(assigns)  %>
-          </div>
+  <div class="p-5 bg-white rounded-2xl shadow-sm dark:bg-gray-800 border border-gray-100 dark:border-gray-700" data-controller="twitch">
+    <div class="flex items-start justify-between mb-4">
+      <div class="flex items-center gap-3">
+        <div class="flex items-center justify-center w-10 h-10 bg-purple-100 dark:bg-purple-900/40 rounded-xl">
+          <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z"/>
+          </svg>
+        </div>
+        <div>
+          <h3 class="font-bold text-gray-900 dark:text-white">Twitch Extension</h3>
+          <p class="text-xs text-gray-500 dark:text-gray-400">Ready to use</p>
         </div>
       </div>
+      <div data-action="mousedown->twitch#toggleOn">
+        <div class="hidden" data-twitch-target="offSwitch"><%= _switch_off(assigns) %></div>
+        <div data-twitch-target="onSwitch"><%= _switch_on(assigns) %></div>
+      </div>
     </div>
-    <div data-twitch-target="errorMessage" class="alert mt-2 hidden text-red-700 bg-red-100" role="alert"></div>
+    <div
+      data-twitch-target="errorMarker"
+      class="hidden flex items-center gap-2 px-3 py-2 text-xs font-medium text-red-700 bg-red-100 rounded-lg dark:bg-red-900/30 dark:text-red-400"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="flex-none w-4 h-4">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+      </svg>
+      Error connecting
+    </div>
+    <div data-twitch-target="errorMessage" class="hidden mt-2 p-2 text-xs text-red-700 bg-red-100 rounded-lg dark:bg-red-900/30 dark:text-red-400" role="alert"></div>
   </div>
 </div>

--- a/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/switch/_switch_off.html.eex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/switch/_switch_off.html.eex
@@ -1,10 +1,10 @@
 <label for="unchecked" class="mt-3 inline-flex items-center cursor-pointer">
   <span class="relative">
-    <span class="block w-10 h-6 bg-gray-400 rounded-full shadow-inner"></span>
+    <span class="block w-10 h-6 bg-gray-400 dark:bg-gray-600 rounded-full shadow-inner"></span>
     <span
       class="absolute block w-4 h-4 mt-1 ml-1 bg-white rounded-full shadow inset-y-0 left-0 focus-within:shadow-outline transition-transform duration-300 ease-in-out">
       <input id="unchecked" type="checkbox" class="absolute opacity-0 w-0 h-0" />
     </span>
   </span>
-  <div class="ml-3 text-sm">Off</div>
+  <div class="ml-3 text-sm text-gray-700 dark:text-gray-300">Off</div>
 </label>

--- a/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/switch/_switch_on.html.eex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/switch/_switch_on.html.eex
@@ -1,10 +1,10 @@
 <label for="checked" class="mt-3 inline-flex items-center cursor-pointer">
   <span class="relative">
-    <span class="block w-10 h-6 bg-gray-400 rounded-full shadow-inner"></span>
+    <span class="block w-10 h-6 bg-gray-400 dark:bg-gray-600 rounded-full shadow-inner"></span>
     <span
       class="absolute block w-4 h-4 mt-1 ml-1 rounded-full shadow inset-y-0 left-0 focus-within:shadow-outline transition-transform duration-300 ease-in-out bg-purple-600 transform translate-x-full">
       <input id="checked" type="checkbox" class="absolute opacity-0 w-0 h-0" />
     </span>
   </span>
-  <span class="ml-3 text-sm">On</span>
+  <span class="ml-3 text-sm text-gray-700 dark:text-gray-300">On</span>
 </label>

--- a/lib/stream_closed_captioner_phoenix_web/live/page_live.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/live/page_live.html.heex
@@ -7,7 +7,7 @@
   <div class="relative px-4 py-20 mx-auto max-w-7xl">
     <div class="flex flex-col items-center text-center">
       <span class="inline-block px-4 py-1 mb-6 text-sm font-semibold tracking-wider text-indigo-300 uppercase bg-indigo-900 bg-opacity-60 rounded-full border border-indigo-700">
-        Free for Twitch Streamers &amp; Zoom Users
+        Free for Twitch Streamers
       </span>
       <h1 class="mb-6 text-5xl font-extrabold leading-tight tracking-tight md:text-7xl">
         Stream Closed
@@ -42,7 +42,7 @@
 </section>
 
 <!-- Video Demo Section -->
-<section class="py-16 bg-gray-900">
+<section class="py-16 bg-gray-900 dark:bg-black">
   <div class="max-w-4xl px-4 mx-auto">
     <h2 class="mb-8 text-2xl font-bold text-center text-white">See it in action</h2>
     <div class="overflow-hidden rounded-2xl shadow-2xl aspect-w-16 aspect-h-9 ring-1 ring-white/10">
@@ -119,7 +119,7 @@
 
 <!-- Getting Started Steps -->
 <section class="py-20 bg-gray-50 dark:bg-gray-800">
-  <div class="max-w-5xl px-4 mx-auto">
+  <div class="max-w-3xl px-4 mx-auto">
     <div class="mb-14 text-center">
       <h2 class="mb-4 text-4xl font-extrabold text-gray-900 dark:text-white">
         Up and running in 4 steps
@@ -127,105 +127,89 @@
       <p class="text-lg text-gray-600 dark:text-gray-400">Getting started takes less than 5 minutes.</p>
     </div>
 
-    <div class="space-y-12">
-      <!-- Step 1 -->
-      <div class="flex flex-col items-start gap-8 sm:flex-row sm:items-center">
-        <div class="flex-shrink-0 flex items-center justify-center w-14 h-14 text-2xl font-black text-white bg-indigo-600 rounded-2xl shadow-lg">
-          1
-        </div>
-        <div class="flex-1">
-          <h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
-            Install the Twitch Extension
-          </h3>
-          <p class="mb-4 text-gray-600 dark:text-gray-400">
-            Add it as a video overlay or panel to your Twitch channel. Works on desktop and mobile viewers.
-          </p>
-          <a
-            target="_blank"
-            href="https://dashboard.twitch.tv/extensions/h1ekceo16erc49snp0sine3k9ccbh9"
-            class="inline-flex items-center px-5 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-500 transition-colors"
-          >
-            Install on Twitch
-            <svg class="w-4 h-4 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-            </svg>
-          </a>
-        </div>
-        <div class="hidden sm:block w-px h-24 bg-gray-200 dark:bg-gray-700 self-start mt-7"></div>
-        <div class="flex-shrink-0 w-full sm:w-64">
-          <%= img_tag(Routes.static_path(@socket, "/images/install-extension.png"),
-            alt: "Twitch extension installation page",
-            class: "w-full rounded-xl shadow-md"
-          ) %>
-        </div>
-      </div>
+    <!-- Vertical timeline -->
+    <div class="relative">
+      <!-- Timeline line -->
+      <div class="absolute left-6 top-6 bottom-6 w-0.5 bg-indigo-200 dark:bg-indigo-800 hidden sm:block"></div>
 
-      <!-- Step 2 -->
-      <div class="flex flex-col-reverse items-start gap-8 sm:flex-row sm:items-center">
-        <div class="flex-shrink-0 w-full sm:w-64">
-          <%= img_tag(Routes.static_path(@socket, "/images/register.png"),
-            alt: "Stream Closed Captioner registration page",
-            class: "w-full rounded-xl shadow-md"
-          ) %>
+      <div class="space-y-8">
+        <!-- Step 1 -->
+        <div class="relative flex gap-6">
+          <div class="flex-shrink-0 relative z-10 flex items-center justify-center w-12 h-12 text-lg font-black text-white bg-indigo-600 rounded-full shadow-lg ring-4 ring-gray-50 dark:ring-gray-800">
+            1
+          </div>
+          <div class="flex-1 pt-1 pb-2">
+            <h3 class="mb-1 text-xl font-bold text-gray-900 dark:text-white">
+              Install the Twitch Extension
+            </h3>
+            <p class="mb-3 text-gray-600 dark:text-gray-400">
+              Add it as a video overlay or panel on your Twitch channel.
+            </p>
+            <a
+              target="_blank"
+              href="https://dashboard.twitch.tv/extensions/h1ekceo16erc49snp0sine3k9ccbh9"
+              class="inline-flex items-center px-4 py-2 text-sm font-semibold text-indigo-700 bg-indigo-100 rounded-lg hover:bg-indigo-200 transition-colors dark:text-indigo-300 dark:bg-indigo-900/50 dark:hover:bg-indigo-900/80"
+            >
+              Install on Twitch
+              <svg class="w-4 h-4 ml-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+            </a>
+          </div>
         </div>
-        <div class="hidden sm:block w-px h-24 bg-gray-200 dark:bg-gray-700 self-start mt-7"></div>
-        <div class="flex-1">
-          <div class="flex-shrink-0 flex items-center justify-center w-14 h-14 mb-4 text-2xl font-black text-white bg-indigo-600 rounded-2xl shadow-lg">
+
+        <!-- Step 2 -->
+        <div class="relative flex gap-6">
+          <div class="flex-shrink-0 relative z-10 flex items-center justify-center w-12 h-12 text-lg font-black text-white bg-indigo-600 rounded-full shadow-lg ring-4 ring-gray-50 dark:ring-gray-800">
             2
           </div>
-          <h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
-            Create Your Account
-          </h3>
-          <p class="mb-4 text-gray-600 dark:text-gray-400">
-            Sign up with your Twitch account for instant access, or use email if you just need Zoom captions.
-          </p>
-          <%= link("Sign up free", to: ~p"/users/register", class: "inline-flex items-center px-5 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-500 transition-colors") %>
+          <div class="flex-1 pt-1 pb-2">
+            <h3 class="mb-1 text-xl font-bold text-gray-900 dark:text-white">
+              Create your free account
+            </h3>
+            <p class="mb-3 text-gray-600 dark:text-gray-400">
+              Sign up with your Twitch account for instant access.
+            </p>
+            <%= link to: ~p"/users/register", class: "inline-flex items-center px-4 py-2 text-sm font-semibold text-indigo-700 bg-indigo-100 rounded-lg hover:bg-indigo-200 transition-colors dark:text-indigo-300 dark:bg-indigo-900/50 dark:hover:bg-indigo-900/80" do %>
+              Sign up free
+            <% end %>
+          </div>
         </div>
-      </div>
 
-      <!-- Step 3 -->
-      <div class="flex flex-col items-start gap-8 sm:flex-row sm:items-center">
-        <div class="flex-shrink-0 flex items-center justify-center w-14 h-14 text-2xl font-black text-white bg-indigo-600 rounded-2xl shadow-lg">
-          3
+        <!-- Step 3 -->
+        <div class="relative flex gap-6">
+          <div class="flex-shrink-0 relative z-10 flex items-center justify-center w-12 h-12 text-lg font-black text-white bg-indigo-600 rounded-full shadow-lg ring-4 ring-gray-50 dark:ring-gray-800">
+            3
+          </div>
+          <div class="flex-1 pt-1 pb-2">
+            <h3 class="mb-1 text-xl font-bold text-gray-900 dark:text-white">
+              Configure your caption settings
+            </h3>
+            <p class="mb-3 text-gray-600 dark:text-gray-400">
+              Pick your spoken language and customize captions appearance.
+            </p>
+            <%= link to: Routes.caption_settings_index_path(@socket, :show), class: "inline-flex items-center px-4 py-2 text-sm font-semibold text-indigo-700 bg-indigo-100 rounded-lg hover:bg-indigo-200 transition-colors dark:text-indigo-300 dark:bg-indigo-900/50 dark:hover:bg-indigo-900/80" do %>
+              Open settings
+            <% end %>
+          </div>
         </div>
-        <div class="flex-1">
-          <h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
-            Configure Your Settings
-          </h3>
-          <p class="mb-4 text-gray-600 dark:text-gray-400">
-            Set your spoken language, Zoom URL, caption style, and any words you want filtered.
-          </p>
-          <%= link("Configure settings", to: Routes.caption_settings_index_path(@socket, :show), class: "inline-flex items-center px-5 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-500 transition-colors") %>
-        </div>
-        <div class="hidden sm:block w-px h-24 bg-gray-200 dark:bg-gray-700 self-start mt-7"></div>
-        <div class="flex-shrink-0 w-full sm:w-64">
-          <%= img_tag(Routes.static_path(@socket, "/images/settings.png"),
-            alt: "Stream Closed Captioner caption settings page",
-            class: "w-full rounded-xl shadow-md"
-          ) %>
-        </div>
-      </div>
 
-      <!-- Step 4 -->
-      <div class="flex flex-col-reverse items-start gap-8 sm:flex-row sm:items-center">
-        <div class="flex-shrink-0 w-full sm:w-64">
-          <%= img_tag(Routes.static_path(@socket, "/images/captions-start.png"),
-            alt: "Stream Closed Captioner start captions button",
-            class: "w-full rounded-xl shadow-md"
-          ) %>
-        </div>
-        <div class="hidden sm:block w-px h-24 bg-gray-200 dark:bg-gray-700 self-start mt-7"></div>
-        <div class="flex-1">
-          <div class="flex-shrink-0 flex items-center justify-center w-14 h-14 mb-4 text-2xl font-black text-white bg-indigo-600 rounded-2xl shadow-lg">
+        <!-- Step 4 -->
+        <div class="relative flex gap-6">
+          <div class="flex-shrink-0 relative z-10 flex items-center justify-center w-12 h-12 text-lg font-black text-white bg-indigo-600 rounded-full shadow-lg ring-4 ring-gray-50 dark:ring-gray-800">
             4
           </div>
-          <h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
-            Click "Start Closed Captions"
-          </h3>
-          <p class="mb-4 text-gray-600 dark:text-gray-400">
-            One button is all it takes. Grant microphone access and you're live — captions appear instantly for your viewers.
-          </p>
-          <%= link("Go to Dashboard", to: Routes.dashboard_path(@socket, :index), class: "inline-flex items-center px-5 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-500 transition-colors") %>
+          <div class="flex-1 pt-1 pb-2">
+            <h3 class="mb-1 text-xl font-bold text-gray-900 dark:text-white">
+              Hit "Start Captions" and go live
+            </h3>
+            <p class="mb-3 text-gray-600 dark:text-gray-400">
+              Grant microphone access and captions appear instantly for your viewers.
+            </p>
+            <%= link to: Routes.dashboard_path(@socket, :index), class: "inline-flex items-center px-4 py-2 text-sm font-semibold text-indigo-700 bg-indigo-100 rounded-lg hover:bg-indigo-200 transition-colors dark:text-indigo-300 dark:bg-indigo-900/50 dark:hover:bg-indigo-900/80" do %>
+              Go to Dashboard
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/lib/stream_closed_captioner_phoenix_web/live/page_live.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/live/page_live.html.heex
@@ -1,219 +1,251 @@
-<section class="px-4 py-24 mx-auto max-w-7xl">
-  <div class="w-full mx-auto text-left md:w-11/12 xl:w-9/12 md:text-center">
-    <h1 class="mb-6 text-4xl font-extrabold leading-none tracking-normal text-gray-900 md:text-6xl md:tracking-tight">
-      Stream Closed Captioner
-    </h1>
-    <p class="px-0 mb-6 text-lg text-gray-600 md:text-xl lg:px-24">
-      Easily add Closed Captions to your Twitch stream or Zoom meeting today with just a few clicks of the mouse.
-    </p>
-    <div class="mb-4 space-x-0 md:space-x-2 md:mb-8">
-      <%= link to: ~p"/users/register", class: "inline-flex items-center justify-center w-full mb-2 btn btn-primary btn-lg sm:w-auto sm:mb-0" do %>
-        Get Started
-        <svg
-          class="w-4 h-4 ml-1"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-            clip-rule="evenodd"
-          />
-        </svg>
-      <% end %>
-    </div>
+<!-- Hero Section -->
+<section class="relative overflow-hidden bg-gradient-to-br from-gray-900 via-gray-800 to-indigo-900 text-white">
+  <div class="absolute inset-0 opacity-10">
+    <div class="absolute top-10 left-10 w-72 h-72 bg-purple-500 rounded-full filter blur-3xl"></div>
+    <div class="absolute bottom-10 right-10 w-96 h-96 bg-blue-500 rounded-full filter blur-3xl"></div>
   </div>
-
-  <div class="aspect-w-16 aspect-h-9">
-    <iframe
-      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-      allowfullscreen=""
-      frameborder="0"
-      src="https://www.youtube.com/embed/eBtWOZcpUzQ"
-      title="Stream Closed Captioner Introduction Video"
-    >
-    </iframe>
-  </div>
-</section>
-
-<section class="px-4 py-20 mx-auto text-white bg-gray-900">
-  <div class="grid items-center grid-cols-1 lg:grid-cols-2 gap-y-10 lg:gap-y-32 gap-x-10 lg:gap-x-24 max-w-5xl mx-auto px-4">
-    <div>
-      <h2 class="mb-3 text-3xl font-extrabold leading-tight tracking-tight text-center sm:text-left md:text-4xl">
-        Start Using it Today
-      </h2>
-      <p class="mb-6 text-lg text-center sm:text-left md:text-xl text-gray-300">
-        Make your streams more accessiable to
-        the hard of hearing, all you have to do is create an account and you get all these awesome features.
+  <div class="relative px-4 py-20 mx-auto max-w-7xl">
+    <div class="flex flex-col items-center text-center">
+      <span class="inline-block px-4 py-1 mb-6 text-sm font-semibold tracking-wider text-indigo-300 uppercase bg-indigo-900 bg-opacity-60 rounded-full border border-indigo-700">
+        Free for Twitch Streamers &amp; Zoom Users
+      </span>
+      <h1 class="mb-6 text-5xl font-extrabold leading-tight tracking-tight md:text-7xl">
+        Stream Closed
+        <span class="text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-purple-400">
+          Captioner
+        </span>
+      </h1>
+      <p class="max-w-2xl mb-10 text-xl text-gray-300 md:text-2xl">
+        Add real-time closed captions to your Twitch stream or Zoom meeting in minutes.
+        Make your content accessible to everyone.
       </p>
-      <%= link("Create an Account",
-        to: ~p"/users/register",
-        class: "w-full btn btn-primary btn-lg sm:w-auto"
-      ) %>
-    </div>
-    <div class="flex flex-col flex-grow space-y-5">
-      <div class="flex items-start">
-        <svg
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          class="flex-none w-5 h-5 mt-1 mr-2 text-primary"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <p class="text-lg text-gray-300">Closed Captions for your Twitch Channel</p>
-      </div>
-      <div class="flex items-start">
-        <svg
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          class="flex-none w-5 h-5 mt-1 mr-2 text-primary"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <p class="text-lg text-gray-300">Closed Captions for your Zoom Meeting</p>
-      </div>
-      <div class="flex items-start">
-        <svg
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          class="flex-none w-5 h-5 mt-1 mr-2 text-primary"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <p class="text-lg text-gray-300">Easy to Use Twitch Viewer Settings</p>
-      </div>
-      <div class="flex items-start">
-        <svg
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          class="flex-none w-5 h-5 mt-1 mr-2 text-primary"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <p class="text-lg text-gray-300">
-          Add Captions to your Twitch VODs using OBS WebSocket for OBS Studio
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="bg-gray-100 border-b">
-  <div class="container max-w-5xl mx-auto m-8">
-    <h2 class="w-full my-2 text-5xl font-black leading-tight text-center text-gray-800">
-      Getting Started is Easy
-    </h2>
-    <div class="w-full mb-4">
-      <div class="h-1 mx-auto gradient w-64 opacity-25 my-0 py-0 rounded-t"></div>
-    </div>
-    <!-- Step 1 --->
-    <div class="flex flex-wrap">
-      <div class="w-full sm:w-1/2 p-6">
-        <h3 class="text-3xl text-gray-800 font-bold leading-none mb-3">
-          Install the Extension on your Twitch channel
-        </h3>
-        <p class="text-gray-600 mb-8">
-          Choose to activate it as a video overlay or panel extension for your channel, it also works on mobile.
-        </p>
+      <div class="flex flex-col gap-4 sm:flex-row sm:gap-6">
+        <%= link to: ~p"/users/register", class: "inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white bg-indigo-600 rounded-xl hover:bg-indigo-500 transition-colors shadow-lg shadow-indigo-900/50" do %>
+          Get Started Free
+          <svg class="w-5 h-5 ml-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
+          </svg>
+        <% end %>
         <a
           target="_blank"
           href="https://dashboard.twitch.tv/extensions/h1ekceo16erc49snp0sine3k9ccbh9"
-          class="w-full btn btn-dark btn-lg sm:w-auto dark:bg-blue-800"
+          class="inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white bg-purple-700 rounded-xl hover:bg-purple-600 transition-colors border border-purple-500"
         >
-          Click to install
+          <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z"/>
+          </svg>
+          Install Twitch Extension
         </a>
       </div>
-      <div class="w-full sm:w-1/2 p-6">
-        <%= img_tag(Routes.static_path(@socket, "/images/install-extension.png"),
-          alt: "Image of the Twitch extension installation page"
-        ) %>
+    </div>
+  </div>
+</section>
+
+<!-- Video Demo Section -->
+<section class="py-16 bg-gray-900">
+  <div class="max-w-4xl px-4 mx-auto">
+    <h2 class="mb-8 text-2xl font-bold text-center text-white">See it in action</h2>
+    <div class="overflow-hidden rounded-2xl shadow-2xl aspect-w-16 aspect-h-9 ring-1 ring-white/10">
+      <iframe
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen=""
+        frameborder="0"
+        src="https://www.youtube.com/embed/eBtWOZcpUzQ"
+        title="Stream Closed Captioner Introduction Video"
+      >
+      </iframe>
+    </div>
+  </div>
+</section>
+
+<!-- Features Section -->
+<section class="py-20 bg-white dark:bg-gray-900">
+  <div class="max-w-6xl px-4 mx-auto">
+    <div class="mb-14 text-center">
+      <h2 class="mb-4 text-4xl font-extrabold text-gray-900 dark:text-white">
+        Everything you need to caption your content
+      </h2>
+      <p class="max-w-2xl mx-auto text-lg text-gray-600 dark:text-gray-400">
+        Create an account and get instant access to all these features — no credit card required.
+      </p>
+    </div>
+    <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+      <!-- Feature 1 -->
+      <div class="flex flex-col items-start p-6 bg-gray-50 dark:bg-gray-800 rounded-2xl">
+        <div class="flex items-center justify-center w-12 h-12 mb-4 bg-indigo-100 dark:bg-indigo-900 rounded-xl">
+          <svg class="w-6 h-6 text-indigo-600 dark:text-indigo-400" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z"/>
+          </svg>
+        </div>
+        <h3 class="mb-2 text-lg font-bold text-gray-900 dark:text-white">Twitch Captions</h3>
+        <p class="text-sm text-gray-600 dark:text-gray-400">Live closed captions sent directly to your Twitch channel via the viewer extension.</p>
+      </div>
+      <!-- Feature 2 -->
+      <div class="flex flex-col items-start p-6 bg-gray-50 dark:bg-gray-800 rounded-2xl">
+        <div class="flex items-center justify-center w-12 h-12 mb-4 bg-blue-100 dark:bg-blue-900 rounded-xl">
+          <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M24 12c0 6.627-5.373 12-12 12S0 18.627 0 12 5.373 0 12 0s12 5.373 12 12zm-4.5-1.5h-15v3h15v-3z"/>
+          </svg>
+        </div>
+        <h3 class="mb-2 text-lg font-bold text-gray-900 dark:text-white">Zoom Meeting Captions</h3>
+        <p class="text-sm text-gray-600 dark:text-gray-400">Send real-time captions to your Zoom meetings so every participant can follow along.</p>
+      </div>
+      <!-- Feature 3 -->
+      <div class="flex flex-col items-start p-6 bg-gray-50 dark:bg-gray-800 rounded-2xl">
+        <div class="flex items-center justify-center w-12 h-12 mb-4 bg-green-100 dark:bg-green-900 rounded-xl">
+          <svg class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+          </svg>
+        </div>
+        <h3 class="mb-2 text-lg font-bold text-gray-900 dark:text-white">Easy Viewer Settings</h3>
+        <p class="text-sm text-gray-600 dark:text-gray-400">Your viewers can customize font size, color, and position directly in the Twitch extension.</p>
+      </div>
+      <!-- Feature 4 -->
+      <div class="flex flex-col items-start p-6 bg-gray-50 dark:bg-gray-800 rounded-2xl">
+        <div class="flex items-center justify-center w-12 h-12 mb-4 bg-red-100 dark:bg-red-900 rounded-xl">
+          <svg class="w-6 h-6 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.069A1 1 0 0121 8.82v6.36a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+        </div>
+        <h3 class="mb-2 text-lg font-bold text-gray-900 dark:text-white">OBS VOD Captions</h3>
+        <p class="text-sm text-gray-600 dark:text-gray-400">Send captions to OBS Studio via WebSocket so your VODs are captioned too.</p>
       </div>
     </div>
-    <!-- Step 2 --->
-    <div class="flex flex-wrap flex-col-reverse sm:flex-row">
-      <div class="w-full sm:w-1/2 p-6 mt-6">
-        <%= img_tag(Routes.static_path(@socket, "/images/register.png"),
-          alt: "Stream Closed Captioner registration page"
-        ) %>
-      </div>
-      <div class="w-full sm:w-1/2 p-6 mt-6">
-        <div class="align-middle">
-          <h3 class="text-3xl text-gray-800 font-bold leading-none mb-3">
-            Sign Up for an Account
+    <div class="mt-12 text-center">
+      <%= link("Create a Free Account", to: ~p"/users/register", class: "inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white bg-indigo-600 rounded-xl hover:bg-indigo-500 transition-colors") %>
+    </div>
+  </div>
+</section>
+
+<!-- Getting Started Steps -->
+<section class="py-20 bg-gray-50 dark:bg-gray-800">
+  <div class="max-w-5xl px-4 mx-auto">
+    <div class="mb-14 text-center">
+      <h2 class="mb-4 text-4xl font-extrabold text-gray-900 dark:text-white">
+        Up and running in 4 steps
+      </h2>
+      <p class="text-lg text-gray-600 dark:text-gray-400">Getting started takes less than 5 minutes.</p>
+    </div>
+
+    <div class="space-y-12">
+      <!-- Step 1 -->
+      <div class="flex flex-col items-start gap-8 sm:flex-row sm:items-center">
+        <div class="flex-shrink-0 flex items-center justify-center w-14 h-14 text-2xl font-black text-white bg-indigo-600 rounded-2xl shadow-lg">
+          1
+        </div>
+        <div class="flex-1">
+          <h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
+            Install the Twitch Extension
           </h3>
-          <p class="text-gray-600 mb-8">
-            You can easily sign up using your Twitch account to get started on your channel, or sign up with e-mail if
-            you want to just use it for Zoom.
+          <p class="mb-4 text-gray-600 dark:text-gray-400">
+            Add it as a video overlay or panel to your Twitch channel. Works on desktop and mobile viewers.
           </p>
-          <%= link("Sign up today",
-            to: ~p"/users/register",
-            class: "w-full btn btn-dark btn-lg sm:w-auto dark:bg-blue-800"
+          <a
+            target="_blank"
+            href="https://dashboard.twitch.tv/extensions/h1ekceo16erc49snp0sine3k9ccbh9"
+            class="inline-flex items-center px-5 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-500 transition-colors"
+          >
+            Install on Twitch
+            <svg class="w-4 h-4 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </a>
+        </div>
+        <div class="hidden sm:block w-px h-24 bg-gray-200 dark:bg-gray-700 self-start mt-7"></div>
+        <div class="flex-shrink-0 w-full sm:w-64">
+          <%= img_tag(Routes.static_path(@socket, "/images/install-extension.png"),
+            alt: "Twitch extension installation page",
+            class: "w-full rounded-xl shadow-md"
           ) %>
         </div>
       </div>
-    </div>
-    <!-- Step 3 --->
-    <div class="flex flex-wrap">
-      <div class="w-fukk sm:w-1/2 p-6">
-        <h3 class="text-3xl text-gray-800 font-bold leading-none mb-3">
-          Get your setting just right
-        </h3>
-        <p class="text-gray-600 mb-8">
-          Open up the settings panel to set your native language or your Zoom URL and more...
-        </p>
-        <%= link("Configure settings",
-          to: Routes.caption_settings_index_path(@socket, :show),
-          class: "w-full btn btn-dark btn-lg sm:w-auto dark:bg-blue-800"
-        ) %>
+
+      <!-- Step 2 -->
+      <div class="flex flex-col-reverse items-start gap-8 sm:flex-row sm:items-center">
+        <div class="flex-shrink-0 w-full sm:w-64">
+          <%= img_tag(Routes.static_path(@socket, "/images/register.png"),
+            alt: "Stream Closed Captioner registration page",
+            class: "w-full rounded-xl shadow-md"
+          ) %>
+        </div>
+        <div class="hidden sm:block w-px h-24 bg-gray-200 dark:bg-gray-700 self-start mt-7"></div>
+        <div class="flex-1">
+          <div class="flex-shrink-0 flex items-center justify-center w-14 h-14 mb-4 text-2xl font-black text-white bg-indigo-600 rounded-2xl shadow-lg">
+            2
+          </div>
+          <h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
+            Create Your Account
+          </h3>
+          <p class="mb-4 text-gray-600 dark:text-gray-400">
+            Sign up with your Twitch account for instant access, or use email if you just need Zoom captions.
+          </p>
+          <%= link("Sign up free", to: ~p"/users/register", class: "inline-flex items-center px-5 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-500 transition-colors") %>
+        </div>
       </div>
-      <div class="w-full sm:w-1/2 p-6">
-        <%= img_tag(Routes.static_path(@socket, "/images/settings.png"),
-          alt: "Stream Closed Captioner caption settings page"
-        ) %>
+
+      <!-- Step 3 -->
+      <div class="flex flex-col items-start gap-8 sm:flex-row sm:items-center">
+        <div class="flex-shrink-0 flex items-center justify-center w-14 h-14 text-2xl font-black text-white bg-indigo-600 rounded-2xl shadow-lg">
+          3
+        </div>
+        <div class="flex-1">
+          <h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
+            Configure Your Settings
+          </h3>
+          <p class="mb-4 text-gray-600 dark:text-gray-400">
+            Set your spoken language, Zoom URL, caption style, and any words you want filtered.
+          </p>
+          <%= link("Configure settings", to: Routes.caption_settings_index_path(@socket, :show), class: "inline-flex items-center px-5 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-500 transition-colors") %>
+        </div>
+        <div class="hidden sm:block w-px h-24 bg-gray-200 dark:bg-gray-700 self-start mt-7"></div>
+        <div class="flex-shrink-0 w-full sm:w-64">
+          <%= img_tag(Routes.static_path(@socket, "/images/settings.png"),
+            alt: "Stream Closed Captioner caption settings page",
+            class: "w-full rounded-xl shadow-md"
+          ) %>
+        </div>
       </div>
-    </div>
-    <!-- Step 4 --->
-    <div class="flex flex-wrap flex-col-reverse sm:flex-row">
-      <div class="w-full sm:w-1/2 p-6 mt-6">
-        <%= img_tag(Routes.static_path(@socket, "/images/captions-start.png"),
-          alt: "Stream Closed Captioner dashboard page focused on the start captions button"
-        ) %>
-      </div>
-      <div class="w-full sm:w-1/2 p-6 mt-6">
-        <div class="align-middle">
-          <h3 class="text-3xl text-gray-800 font-bold leading-none mb-3">
+
+      <!-- Step 4 -->
+      <div class="flex flex-col-reverse items-start gap-8 sm:flex-row sm:items-center">
+        <div class="flex-shrink-0 w-full sm:w-64">
+          <%= img_tag(Routes.static_path(@socket, "/images/captions-start.png"),
+            alt: "Stream Closed Captioner start captions button",
+            class: "w-full rounded-xl shadow-md"
+          ) %>
+        </div>
+        <div class="hidden sm:block w-px h-24 bg-gray-200 dark:bg-gray-700 self-start mt-7"></div>
+        <div class="flex-1">
+          <div class="flex-shrink-0 flex items-center justify-center w-14 h-14 mb-4 text-2xl font-black text-white bg-indigo-600 rounded-2xl shadow-lg">
+            4
+          </div>
+          <h3 class="mb-2 text-2xl font-bold text-gray-900 dark:text-white">
             Click "Start Closed Captions"
           </h3>
-          <p class="text-gray-600 mb-8">
-            Click a single button to start Closed Captioning on your Twitch channel or Zoom meeting.
+          <p class="mb-4 text-gray-600 dark:text-gray-400">
+            One button is all it takes. Grant microphone access and you're live — captions appear instantly for your viewers.
           </p>
-          <%= link("Start using it today!",
-            to: Routes.dashboard_path(@socket, :index),
-            class: "w-full btn btn-dark btn-lg sm:w-auto dark:bg-blue-800"
-          ) %>
+          <%= link("Go to Dashboard", to: Routes.dashboard_path(@socket, :index), class: "inline-flex items-center px-5 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-500 transition-colors") %>
         </div>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- Final CTA Banner -->
+<section class="py-16 bg-indigo-700 dark:bg-indigo-800">
+  <div class="max-w-3xl px-4 mx-auto text-center">
+    <h2 class="mb-4 text-3xl font-extrabold text-white md:text-4xl">
+      Ready to make your stream accessible?
+    </h2>
+    <p class="mb-8 text-lg text-indigo-200">
+      Join streamers who are already using Stream CC to reach more viewers.
+    </p>
+    <div class="flex flex-col gap-4 sm:flex-row sm:justify-center">
+      <%= link to: ~p"/users/register", class: "inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-indigo-700 bg-white rounded-xl hover:bg-indigo-50 transition-colors" do %>
+        Create Free Account
+      <% end %>
+      <%= link("I already have an account →", to: ~p"/users/log_in", class: "inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white hover:text-indigo-200 transition-colors") %>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Homepage:
- New gradient hero section with stronger visual hierarchy and brand identity
- Video demo in its own focused section
- Feature cards with icons replacing plain text feature list
- Numbered step-by-step getting started with cleaner layout
- Final CTA banner to drive sign-ups
- Fix typos ("accessiable", "w-fukk")

Dashboard:
- Promote "Start Captions" to primary hero position at the top
- Redesign integration cards (Twitch, Zoom, OBS) with consistent visual style
- Cleaner translation info panel with data in a 3-column stat layout
- Quick Start guide as a collapsible section with numbered steps
- Announcement banner moved to top with better styling
- Twitch indicator components updated to match new card style

https://claude.ai/code/session_0167DBwZXwRDU4dpPyej5qMD