### PR TITLE
[Test Improver] test: add tests for Twitch.send_pubsub_message/2

### DIFF
--- a/test/stream_closed_captioner_phoenix/services/twitch_test.exs
+++ b/test/stream_closed_captioner_phoenix/services/twitch_test.exs
@@ -1,0 +1,72 @@
+defmodule StreamClosedCaptionerPhoenix.Services.TwitchTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Twitch.Extension.CaptionsPayload
+
+  @channel_id "123456"
+  @payload %CaptionsPayload{interim: "hello", final: "hello world", delay: 0.5}
+
+  describe "send_pubsub_message/2" do
+    test "returns error when channel_id is nil" do
+      assert {:error, "Missing Channel ID"} =
+               Twitch.send_pubsub_message(@payload, nil)
+    end
+
+    test "returns {:ok, payload} on 204 response" do
+      expect(Twitch.MockExtension, :send_pubsub_message_for, fn _credentials,
+                                                                 _channel_id,
+                                                                 _payload ->
+        {:ok, %HTTPoison.Response{status_code: 204, body: ""}}
+      end)
+
+      assert {:ok, @payload} = Twitch.send_pubsub_message(@payload, @channel_id)
+    end
+
+    test "returns {:error, message} on 400 response" do
+      expect(Twitch.MockExtension, :send_pubsub_message_for, fn _credentials,
+                                                                 _channel_id,
+                                                                 _payload ->
+        {:ok, %HTTPoison.Response{status_code: 400, body: "Bad Request"}}
+      end)
+
+      assert {:error, "Request was rejected"} =
+               Twitch.send_pubsub_message(@payload, @channel_id)
+    end
+
+    test "returns {:error, message} on 500 response" do
+      expect(Twitch.MockExtension, :send_pubsub_message_for, fn _credentials,
+                                                                 _channel_id,
+                                                                 _payload ->
+        {:ok, %HTTPoison.Response{status_code: 500, body: "Internal Server Error"}}
+      end)
+
+      assert {:error, "500, Twitch throwing errors for some reason."} =
+               Twitch.send_pubsub_message(@payload, @channel_id)
+    end
+
+    test "returns {:error, message} on 502 response" do
+      expect(Twitch.MockExtension, :send_pubsub_message_for, fn _credentials,
+                                                                 _channel_id,
+                                                                 _payload ->
+        {:ok, %HTTPoison.Response{status_code: 502, body: "Bad Gateway"}}
+      end)
+
+      assert {:error, "502, cant reach Twitch atm."} =
+               Twitch.send_pubsub_message(@payload, @channel_id)
+    end
+
+    test "returns {:error, reason} on HTTPoison.Error" do
+      expect(Twitch.MockExtension, :send_pubsub_message_for, fn _credentials,
+                                                                 _channel_id,
+                                                                 _payload ->
+        {:error, %HTTPoison.Error{reason: :timeout}}
+      end)
+
+      assert {:error, :timeout} = Twitch.send_pubsub_message(@payload, @channel_id)
+    end
+  end
+end


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant for test improvements.*

## Goal and Rationale

`Twitch.send_pubsub_message/2` in `lib/stream_closed_captioner_phoenix/services/twitch.ex` had **zero test coverage**. This function handles the real-time caption delivery path to Twitch's extension pubsub system — the core feature of this application. Each response code branch maps to a distinct user-visible behavior, making these branches valuable to guard.

## Approach

Used the existing `Twitch.MockExtension` Mox infrastructure (already configured in `test/test_helper.exs` and `config/test.exs`) to test all response branches without any HTTP calls or production-code changes.

Six tests cover:

| Test | What it guards |
|------|---------------|
| `nil` channel_id | Guard clause returns early with correct error |
| 204 response | Success path returns `{:ok, payload}` with the original payload |
| 400 response | Rejected request maps to user-friendly error message |
| 500 response | Server error maps to correct error string |
| 502 response | Gateway error maps to correct error string |
| `HTTPoison.Error` | Network failure propagates `reason` correctly |

## Coverage Impact

Added 6 tests covering all branches of `send_pubsub_message/2`. No coverage tooling run locally (Coveralls is the CI pipeline).

## Test Status

```
$ MIX_ENV=test mix test test/stream_closed_captioner_phoenix/services/twitch_test.exs
......
Finished in 0.06 seconds (0.06s async, 0.00s sync)
6 tests, 0 failures
```

Full suite: `220 tests, 1 failure, 1 skipped` — the 1 failure is a pre-existing issue in `settings_test.exs` that makes a live HTTP call to Twitch OAuth (blocked by sandbox network), unrelated to these changes.

## Trade-offs

- Tests are lightweight and use `async: true` (no DB needed)
- Mock expectations use `_` wildcards for arguments we don't care about, keeping tests focused on response-mapping logic
- No production code changes required




> Generated by [Daily Test Improver](https://github.com/talk2MeGooseman/stream_closed_captioner_phoenix/actions/runs/22971694140)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/442992eda2ccb11ee75a39c019ec6d38ae5a84a2/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@442992eda2ccb11ee75a39c019ec6d38ae5a84a2
> ```

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `data.iana.org`
> - `id.twitch.tv`
>
> </details>


<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, id: 22971694140, workflow_id: daily-test-improver, run: https://github.com/talk2MeGooseman/stream_closed_captioner_phoenix/actions/runs/22971694140 -->

<!-- gh-aw-workflow-id: daily-test-improver -->