### PR TITLE
fix: Resolve HEEx email template function name collision in Layouts

### DIFF
--- a/lib/stream_closed_captioner_phoenix_web/components/layouts.ex
+++ b/lib/stream_closed_captioner_phoenix_web/components/layouts.ex
@@ -2,5 +2,12 @@ defmodule StreamClosedCaptionerPhoenixWeb.Layouts do
   @moduledoc false
   use StreamClosedCaptionerPhoenixWeb, :html
 
-  embed_templates "layouts/*"
+  embed_templates "layouts/email.html", suffix: "_html"
+  embed_templates "layouts/email.text", suffix: "_text"
+  embed_templates "layouts/_*"
+  embed_templates "layouts/a*"
+  embed_templates "layouts/l*"
+  embed_templates "layouts/r*"
+  embed_templates "layouts/s*"
+  embed_templates "layouts/t*"
 end


### PR DESCRIPTION
## Problem

`embed_templates "layouts/*"` caused both `email.html.heex` and `email.text.heex` to compile to the same `email/1` function in `Layouts`. The HEEx engine generates a catch-all change-tracking clause for the HTML template, making the text template's matching clause unreachable -- triggering a compiler warning that fails `mix compile --warnings-as-errors`.

## Root Cause

`Phoenix.Component.__embed__/2` calls `Path.rootname` twice, stripping both extensions:
- `email.html.heex` -> `email.html` -> `email` -> function `email/1`
- `email.text.heex` -> `email.text` -> `email` -> function `email/1`

Erlang's `Path.wildcard` / `:filelib.wildcard` does **not** support character class negation (`[!e]*` or `[^e]*`), so there is no clean way to glob everything except email templates in a single pattern.

## Fix

Replace the single catch-all glob with:

1. **Explicit suffix-qualified calls** for the two email templates, generating unique function names (`email_html/1` and `email_text/1`).

2. **Explicit first-character prefix patterns** for the remaining templates (`_*`, `a*`, `l*`, `r*`, `s*`, `t*`) -- none start with `e`, so email templates are excluded without negation syntax.

`mix compile --warnings-as-errors` now passes cleanly.

## Notes

The renamed compiled functions (`email_html/1`, `email_text/1`) do not affect runtime email rendering. `emails.ex` passes string layout names to Bamboo (`"email.html"`, `"email.text"`), not direct function calls to `Layouts`.

If new layout templates are added in the future, add the appropriate prefix pattern to `layouts.ex` if the filename starts with a letter not already covered.