### PR TITLE
feat: add Gemini 2.5 Flash-Lite translation backend behind FunWithFlags

### DIFF
--- a/.squad/agents/morpheus/charter.md
+++ b/.squad/agents/morpheus/charter.md
@@ -18,10 +18,22 @@
 
 ## How I Work
 
+- Invoke `brainstorming` skill before any architecture decision or feature scoping — **hard gate**
+- Invoke `requesting-code-review` skill before declaring any review work done — **hard gate**
 - Read `.squad/decisions.md` before every task — team decisions are the architecture's memory
 - Think in fault domains: what breaks, does it fail gracefully?
 - Make trade-offs explicit rather than hiding them in implementation
 - Write ADR-style decisions to `.squad/decisions/inbox/` for lasting choices
+
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `brainstorming` | Before any architecture decision, feature scoping, or design work | **Hard** — must invoke before proceeding |
+| `writing-plans` | Before breaking down complex multi-step work for the team | Soft — invoke when scope is multi-file or multi-session |
+| `requesting-code-review` | After completing architecture/design review, before declaring done | **Hard** — must invoke before proceeding |
+
+Use: `skill("brainstorming")`, `skill("writing-plans")`, `skill("requesting-code-review")`.
 
 ## Boundaries
 
@@ -44,6 +56,7 @@
 Before starting: run `git rev-parse --show-toplevel` for repo root, or use `TEAM ROOT` from spawn prompt. Resolve all `.squad/` paths from root — don't assume CWD is repo root.
 
 Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
 Write decisions to `.squad/decisions/inbox/morpheus-{brief-slug}.md` — Scribe merges.
 Flag if need another member's input.
 

--- a/.squad/agents/neo/charter.md
+++ b/.squad/agents/neo/charter.md
@@ -20,12 +20,22 @@
 
 ## How I Work
 
+- Invoke `test-driven-development` skill before writing any new LiveView or JS code — **hard gate**
 - Use `phx-*` bindings for LiveView; avoid JS for things LiveView handles natively
 - Use `connected?(socket)` checks before PubSub subscribe in `mount/3`
 - Minimize socket assigns — only what template needs
 - Use `phx-debounce` for expensive input ops
 - Understand Twitch Extension JWT flow — browser sends Twitch-signed JWT; server validates via GraphQL `Context` plug
 - Write to `.squad/decisions/inbox/neo-{slug}.md` for non-obvious frontend pattern choices
+
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `test-driven-development` | Before writing any new LiveView or JS code | **Hard** — must invoke before writing implementation |
+| `brainstorming` | Before building new UI flows or components with significant user interaction | Soft — invoke when the UX design is non-obvious |
+
+Use: `skill("test-driven-development")`, `skill("brainstorming")`.
 
 ## Boundaries
 
@@ -48,6 +58,7 @@
 Before starting: run `git rev-parse --show-toplevel` for repo root, or use `TEAM ROOT` from spawn prompt. Resolve all `.squad/` paths from root — don't assume CWD is repo root.
 
 Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
 Write decisions to `.squad/decisions/inbox/neo-{brief-slug}.md` — Scribe merges.
 Flag if need another member's input.
 

--- a/.squad/agents/oracle/charter.md
+++ b/.squad/agents/oracle/charter.md
@@ -28,6 +28,14 @@
 - Telemetry event: `[:stream_closed_captioner_phoenix, :audit_log]`
 - Redact before logging: `access_token`, `refresh_token`, `token`, `password`, `current_password`, `encrypted_password`, `azure_service_key`
 
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `requesting-code-review` | After completing security audit, before issuing merge approval or block decision | **Hard** — must invoke before issuing final verdict |
+
+Use: `skill("requesting-code-review")`.
+
 ## Merge-Blocking Criteria
 
 Block merge if ANY of these are true:
@@ -58,6 +66,7 @@ Block merge if ANY of these are true:
 Before starting: run `git rev-parse --show-toplevel` for repo root, or use `TEAM ROOT` from spawn prompt. Resolve all `.squad/` paths from root — don't assume CWD is repo root.
 
 Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
 Write decisions to `.squad/decisions/inbox/oracle-{brief-slug}.md` — Scribe merges.
 Flag if need another member's input.
 

--- a/.squad/agents/ralph/charter.md
+++ b/.squad/agents/ralph/charter.md
@@ -15,5 +15,14 @@ Persistent memory agent; maintains context across sessions.
 ## Work Style
 
 - Read project context and decisions before starting
+- Read `.squad/superpowers.md` before starting
 - Communicate clearly with team
 - Follow established patterns and conventions
+
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `find-skills` | When encountering an unfamiliar task type | Soft — invoke to discover which skill applies |
+
+Use: `skill("find-skills")`.

--- a/.squad/agents/scribe/charter.md
+++ b/.squad/agents/scribe/charter.md
@@ -15,5 +15,14 @@ Documentation specialist maintaining history, decisions, and technical records.
 ## Work Style
 
 - Read project context and decisions before starting
+- Read `.squad/superpowers.md` before starting
 - Communicate clearly with team
 - Follow established patterns and conventions
+
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `writing-plans` | When tasked with complex documentation or multi-file decision consolidation | Soft — invoke when the scope spans multiple documents or sessions |
+
+Use: `skill("writing-plans")`.

--- a/.squad/agents/tank/charter.md
+++ b/.squad/agents/tank/charter.md
@@ -21,6 +21,7 @@
 
 ## How I Work
 
+- Invoke `test-driven-development` skill at the start of every testing task — **hard gate**, this skill drives Tank's primary workflow
 - `DataCase` for context/schema logic, `ConnCase` for controllers/LiveView/GraphQL, `ChannelCase` for channels
 - `async: true` only when test doesn't touch global state (Phoenix.Tracker, Presence)
 - `UserTrackerTest` never `async: true` — touches global Phoenix.Tracker state
@@ -28,6 +29,14 @@
 - `insert(:user)` pre-builds `stream_settings` and `bits_balance` — update those associations, never insert new ones
 - Verify LiveView side effects through DB state, not flash (Phoenix 0.19 limitation)
 - Run `mix test` before declaring done — no failing tests accepted
+
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `test-driven-development` | At the start of every testing task | **Hard** — this skill IS Tank's primary workflow; always invoke first |
+
+Use: `skill("test-driven-development")`.
 
 ## Boundaries
 
@@ -50,6 +59,7 @@
 Before starting: run `git rev-parse --show-toplevel` for repo root, or use `TEAM ROOT` from spawn prompt. Resolve all `.squad/` paths from root — don't assume CWD is repo root.
 
 Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
 Write decisions to `.squad/decisions/inbox/tank-{brief-slug}.md` — Scribe merges.
 Flag if need another member's input.
 

--- a/.squad/agents/trinity/charter.md
+++ b/.squad/agents/trinity/charter.md
@@ -21,12 +21,22 @@
 
 ## How I Work
 
+- Invoke `test-driven-development` skill before writing any new feature code — **hard gate**
 - Thin-controller pattern — business logic in contexts, not channels or resolvers
 - Tagged tuples (`{:ok, value}` / `{:error, reason}`) for all fallible ops
 - `Ecto.Multi` for any multi-step DB transaction requiring atomicity
 - Preload associations deliberately — no N+1 queries
 - Secrets from env config or `EncryptedBinary` type, never hardcoded
 - Write to `.squad/decisions/inbox/trinity-{slug}.md` for pattern choices that affect codebase
+
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `test-driven-development` | Before writing any new feature code | **Hard** — must invoke before writing implementation |
+| `brainstorming` | Before designing complex backend patterns (new pipeline stages, major context rewrites) | Soft — invoke when the design is non-obvious |
+
+Use: `skill("test-driven-development")`, `skill("brainstorming")`.
 
 ## Boundaries
 
@@ -49,6 +59,7 @@
 Before starting: run `git rev-parse --show-toplevel` for repo root, or use `TEAM ROOT` from spawn prompt. Resolve all `.squad/` paths from root — don't assume CWD is repo root.
 
 Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
 Write decisions to `.squad/decisions/inbox/trinity-{brief-slug}.md` — Scribe merges.
 Flag if need another member's input.
 

--- a/.squad/superpowers.md
+++ b/.squad/superpowers.md
@@ -1,0 +1,59 @@
+# Superpowers — Skills Contract
+
+Read this at the start of every session alongside `.squad/decisions.md`.
+
+## The Hard Gate Rule
+
+Check for skills before any action. If there is even a **1% chance** a skill applies, invoke it. Do not start work, ask clarifying questions, or explore the codebase before checking.
+
+## How to Invoke
+
+Use the `skill` tool:
+
+```
+skill("skill-name")
+```
+
+The skill content loads and you follow it exactly.
+
+## Subagent Note
+
+When dispatched as a subagent with a specific task, skip `using-superpowers`. All other skills still apply — check for relevant skills before starting your task.
+
+## Priority Rule
+
+**Process skills before implementation skills:**
+
+1. **Process first** — `brainstorming`, `test-driven-development` — establish *how* to approach the work
+2. **Implementation second** — domain-specific skills — guide *how* to execute
+
+## Skills Catalog
+
+### Workflow Skills
+
+| Skill | Purpose | Invoke when |
+|-------|---------|-------------|
+| `brainstorming` | Explores intent and design before building | Before any creative work — new features, components, behavior changes, architecture decisions |
+| `test-driven-development` | Enforces TDD workflow | Before writing any implementation code |
+| `writing-plans` | Creates bite-sized implementation plans from a spec | After brainstorming is complete, before implementation begins |
+| `requesting-code-review` | Reviews completed work against plan and coding standards | After completing a logical chunk of work, before declaring done |
+| `find-skills` | Discovers available skills for an unfamiliar task type | When you don't know which skill applies |
+
+### Communication Skills
+
+| Skill | Purpose | Invoke when |
+|-------|---------|-------------|
+| `caveman` | Ultra-compressed output (~75% fewer tokens) | When user requests brevity or token efficiency |
+| `caveman-review` | Compressed code review comments | When reviewing PRs or diffs |
+| `caveman-compress` | Compresses memory/preference files to caveman format | When compressing CLAUDE.md or similar files |
+
+### Project Skills
+
+| Skill | Purpose | Invoke when |
+|-------|---------|-------------|
+| `elixir-phoenix-best-practices` | Enforces Elixir/Phoenix coding standards | When writing or reviewing Elixir/Phoenix code |
+| `refactor` | Surgical code refactoring without behavior change | When improving code quality without adding features |
+
+## Agent-Specific Rules
+
+Each agent's charter has a `## Skills` section with domain-specific trigger rules. Your charter is the authoritative source for which skills you invoke and when.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -89,5 +89,6 @@ config :stream_closed_captioner_phoenix, StreamClosedCaptionerPhoenix.Mailer,
 config :stream_closed_captioner_phoenix, twitch_extension_client: Twitch.Extension
 config :stream_closed_captioner_phoenix, twitch_helix_client: Twitch.Helix
 config :stream_closed_captioner_phoenix, azure_cognitive_client: Azure.Cognitive
+config :stream_closed_captioner_phoenix, gemini_cognitive_client: Gemini.Cognitive
 
 import_config "dev.secret.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,6 +20,7 @@ if config_env() == :prod do
   config :stream_closed_captioner_phoenix, twitch_extension_client: Twitch.Extension
   config :stream_closed_captioner_phoenix, twitch_helix_client: Twitch.Helix
   config :stream_closed_captioner_phoenix, azure_cognitive_client: Azure.Cognitive
+  config :stream_closed_captioner_phoenix, gemini_cognitive_client: Gemini.Cognitive
 
   if System.get_env("USE_SSL") == "true" do
     config :stream_closed_captioner_phoenix, StreamClosedCaptionerPhoenix.Repo,

--- a/config/test.exs
+++ b/config/test.exs
@@ -34,6 +34,7 @@ config :stream_closed_captioner_phoenix, StreamClosedCaptionerPhoenix.Mailer,
 config :stream_closed_captioner_phoenix, twitch_extension_client: Twitch.MockExtension
 config :stream_closed_captioner_phoenix, twitch_helix_client: Twitch.MockHelix
 config :stream_closed_captioner_phoenix, azure_cognitive_client: Azure.MockCognitive
+config :stream_closed_captioner_phoenix, gemini_cognitive_client: Gemini.MockCognitive
 
 config :stream_closed_captioner_phoenix, Oban, testing: :manual
 

--- a/docs/superpowers/plans/2026-04-24-squad-superpowers-integration.md
+++ b/docs/superpowers/plans/2026-04-24-squad-superpowers-integration.md
@@ -1,0 +1,609 @@
+# Squad Superpowers Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the superpowers skills system into every squad agent's workflow via a shared contract doc and agent-specific charter updates.
+
+**Architecture:** Create `.squad/superpowers.md` as a shared skills reference (read at session start alongside `decisions.md`), then update each agent charter with a `## Skills` section and hard-gate callouts in `## How I Work`.
+
+**Tech Stack:** Markdown file edits only — no code changes.
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|--------------|
+| `.squad/superpowers.md` | Create | New shared skills contract |
+| `.squad/agents/morpheus/charter.md` | Modify | Add `## Skills`, update `## How I Work`, update `## Collaboration` |
+| `.squad/agents/trinity/charter.md` | Modify | Add `## Skills`, update `## How I Work`, update `## Collaboration` |
+| `.squad/agents/neo/charter.md` | Modify | Add `## Skills`, update `## How I Work`, update `## Collaboration` |
+| `.squad/agents/tank/charter.md` | Modify | Add `## Skills`, update `## How I Work`, update `## Collaboration` |
+| `.squad/agents/oracle/charter.md` | Modify | Add `## Skills`, update `## Collaboration` |
+| `.squad/agents/scribe/charter.md` | Modify | Add `## Skills`, update `## Work Style` |
+| `.squad/agents/ralph/charter.md` | Modify | Add `## Skills`, update `## Work Style` |
+
+---
+
+## Task 1: Create `.squad/superpowers.md`
+
+**Files:**
+- Create: `.squad/superpowers.md`
+
+- [ ] **Step 1: Create the file**
+
+Create `.squad/superpowers.md` with this exact content:
+
+```markdown
+# Superpowers — Skills Contract
+
+Read this at the start of every session alongside `.squad/decisions.md`.
+
+## The Hard Gate Rule
+
+Check for skills before any action. If there is even a **1% chance** a skill applies, invoke it. Do not start work, ask clarifying questions, or explore the codebase before checking.
+
+## How to Invoke
+
+Use the `skill` tool:
+
+```
+skill("skill-name")
+```
+
+The skill content loads and you follow it exactly.
+
+## Subagent Note
+
+When dispatched as a subagent with a specific task, skip `using-superpowers`. All other skills still apply — check for relevant skills before starting your task.
+
+## Priority Rule
+
+**Process skills before implementation skills:**
+
+1. **Process first** — `brainstorming`, `test-driven-development` — establish *how* to approach the work
+2. **Implementation second** — domain-specific skills — guide *how* to execute
+
+## Skills Catalog
+
+### Workflow Skills
+
+| Skill | Purpose | Invoke when |
+|-------|---------|-------------|
+| `brainstorming` | Explores intent and design before building | Before any creative work — new features, components, behavior changes, architecture decisions |
+| `test-driven-development` | Enforces TDD workflow | Before writing any implementation code |
+| `writing-plans` | Creates bite-sized implementation plans from a spec | After brainstorming is complete, before implementation begins |
+| `requesting-code-review` | Reviews completed work against plan and coding standards | After completing a logical chunk of work, before declaring done |
+| `find-skills` | Discovers available skills for an unfamiliar task type | When you don't know which skill applies |
+
+### Communication Skills
+
+| Skill | Purpose | Invoke when |
+|-------|---------|-------------|
+| `caveman` | Ultra-compressed output (~75% fewer tokens) | When user requests brevity or token efficiency |
+| `caveman-review` | Compressed code review comments | When reviewing PRs or diffs |
+| `caveman-compress` | Compresses memory/preference files to caveman format | When compressing CLAUDE.md or similar files |
+
+### Project Skills
+
+| Skill | Purpose | Invoke when |
+|-------|---------|-------------|
+| `elixir-phoenix-best-practices` | Enforces Elixir/Phoenix coding standards | When writing or reviewing Elixir/Phoenix code |
+| `refactor` | Surgical code refactoring without behavior change | When improving code quality without adding features |
+
+## Agent-Specific Rules
+
+Each agent's charter has a `## Skills` section with domain-specific trigger rules. Your charter is the authoritative source for which skills you invoke and when.
+```
+
+- [ ] **Step 2: Verify the file was created**
+
+```bash
+cat .squad/superpowers.md
+```
+
+Expected: Full content renders correctly with all three skill tables visible.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .squad/superpowers.md
+git commit -m "squad: add superpowers skills contract
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 2: Update Morpheus Charter
+
+**Files:**
+- Modify: `.squad/agents/morpheus/charter.md`
+
+- [ ] **Step 1: Add hard-gate callouts to `## How I Work`**
+
+In `.squad/agents/morpheus/charter.md`, find the `## How I Work` section:
+
+```markdown
+## How I Work
+
+- Read `.squad/decisions.md` before every task — team decisions are the architecture's memory
+- Think in fault domains: what breaks, does it fail gracefully?
+- Make trade-offs explicit rather than hiding them in implementation
+- Write ADR-style decisions to `.squad/decisions/inbox/` for lasting choices
+```
+
+Replace with:
+
+```markdown
+## How I Work
+
+- Invoke `brainstorming` skill before any architecture decision or feature scoping — **hard gate**
+- Invoke `requesting-code-review` skill before declaring any review work done — **hard gate**
+- Read `.squad/decisions.md` before every task — team decisions are the architecture's memory
+- Think in fault domains: what breaks, does it fail gracefully?
+- Make trade-offs explicit rather than hiding them in implementation
+- Write ADR-style decisions to `.squad/decisions/inbox/` for lasting choices
+```
+
+- [ ] **Step 2: Add `## Skills` section after `## How I Work`**
+
+Insert the following block between `## How I Work` and `## Boundaries`:
+
+```markdown
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `brainstorming` | Before any architecture decision, feature scoping, or design work | **Hard** — must invoke before proceeding |
+| `writing-plans` | Before breaking down complex multi-step work for the team | Soft — invoke when scope is multi-file or multi-session |
+| `requesting-code-review` | After completing architecture/design review, before declaring done | **Hard** — must invoke before proceeding |
+
+Use: `skill("brainstorming")`, `skill("writing-plans")`, `skill("requesting-code-review")`.
+
+```
+
+- [ ] **Step 3: Update `## Collaboration` to reference `superpowers.md`**
+
+Find:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+```
+
+Replace with:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -n "superpowers\|brainstorming\|requesting-code-review\|## Skills" .squad/agents/morpheus/charter.md
+```
+
+Expected: Lines for the `## Skills` heading, both hard-gate entries in How I Work, and the superpowers.md reference in Collaboration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .squad/agents/morpheus/charter.md
+git commit -m "squad(morpheus): wire superpowers skills into charter
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 3: Update Trinity Charter
+
+**Files:**
+- Modify: `.squad/agents/trinity/charter.md`
+
+- [ ] **Step 1: Add hard-gate callout to `## How I Work`**
+
+Find the `## How I Work` section opening:
+
+```markdown
+## How I Work
+
+- Thin-controller pattern — business logic in contexts, not channels or resolvers
+```
+
+Replace with:
+
+```markdown
+## How I Work
+
+- Invoke `test-driven-development` skill before writing any new feature code — **hard gate**
+- Thin-controller pattern — business logic in contexts, not channels or resolvers
+```
+
+- [ ] **Step 2: Add `## Skills` section after `## How I Work`**
+
+Insert between `## How I Work` and `## Boundaries`:
+
+```markdown
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `test-driven-development` | Before writing any new feature code | **Hard** — must invoke before writing implementation |
+| `brainstorming` | Before designing complex backend patterns (new pipeline stages, major context rewrites) | Soft — invoke when the design is non-obvious |
+
+Use: `skill("test-driven-development")`, `skill("brainstorming")`.
+
+```
+
+- [ ] **Step 3: Update `## Collaboration`**
+
+Find:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+```
+
+Replace with:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -n "superpowers\|test-driven-development\|## Skills" .squad/agents/trinity/charter.md
+```
+
+Expected: Hard-gate line in How I Work, `## Skills` section, superpowers.md reference in Collaboration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .squad/agents/trinity/charter.md
+git commit -m "squad(trinity): wire superpowers skills into charter
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 4: Update Neo Charter
+
+**Files:**
+- Modify: `.squad/agents/neo/charter.md`
+
+- [ ] **Step 1: Add hard-gate callout to `## How I Work`**
+
+Find:
+
+```markdown
+## How I Work
+
+- Use `phx-*` bindings for LiveView; avoid JS for things LiveView handles natively
+```
+
+Replace with:
+
+```markdown
+## How I Work
+
+- Invoke `test-driven-development` skill before writing any new LiveView or JS code — **hard gate**
+- Use `phx-*` bindings for LiveView; avoid JS for things LiveView handles natively
+```
+
+- [ ] **Step 2: Add `## Skills` section after `## How I Work`**
+
+Insert between `## How I Work` and `## Boundaries`:
+
+```markdown
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `test-driven-development` | Before writing any new LiveView or JS code | **Hard** — must invoke before writing implementation |
+| `brainstorming` | Before building new UI flows or components with significant user interaction | Soft — invoke when the UX design is non-obvious |
+
+Use: `skill("test-driven-development")`, `skill("brainstorming")`.
+
+```
+
+- [ ] **Step 3: Update `## Collaboration`**
+
+Find:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+```
+
+Replace with:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -n "superpowers\|test-driven-development\|## Skills" .squad/agents/neo/charter.md
+```
+
+Expected: Hard-gate line in How I Work, `## Skills` section, superpowers.md reference in Collaboration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .squad/agents/neo/charter.md
+git commit -m "squad(neo): wire superpowers skills into charter
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 5: Update Tank Charter
+
+**Files:**
+- Modify: `.squad/agents/tank/charter.md`
+
+- [ ] **Step 1: Add hard-gate callout to `## How I Work`**
+
+Find:
+
+```markdown
+## How I Work
+
+- `DataCase` for context/schema logic, `ConnCase` for controllers/LiveView/GraphQL, `ChannelCase` for channels
+```
+
+Replace with:
+
+```markdown
+## How I Work
+
+- Invoke `test-driven-development` skill at the start of every testing task — **hard gate**, this skill drives Tank's primary workflow
+- `DataCase` for context/schema logic, `ConnCase` for controllers/LiveView/GraphQL, `ChannelCase` for channels
+```
+
+- [ ] **Step 2: Add `## Skills` section after `## How I Work`**
+
+Insert between `## How I Work` and `## Boundaries`:
+
+```markdown
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `test-driven-development` | At the start of every testing task | **Hard** — this skill IS Tank's primary workflow; always invoke first |
+
+Use: `skill("test-driven-development")`.
+
+```
+
+- [ ] **Step 3: Update `## Collaboration`**
+
+Find:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+```
+
+Replace with:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -n "superpowers\|test-driven-development\|## Skills" .squad/agents/tank/charter.md
+```
+
+Expected: Hard-gate line in How I Work, `## Skills` section, superpowers.md reference in Collaboration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .squad/agents/tank/charter.md
+git commit -m "squad(tank): wire superpowers skills into charter
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 6: Update Oracle Charter
+
+**Files:**
+- Modify: `.squad/agents/oracle/charter.md`
+
+- [ ] **Step 1: Add `## Skills` section after `## How I Work`**
+
+Oracle's `## How I Work` ends before `## Merge-Blocking Criteria`. Insert between `## How I Work` and `## Merge-Blocking Criteria`:
+
+```markdown
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `requesting-code-review` | After completing security audit, before issuing merge approval or block decision | **Hard** — must invoke before issuing final verdict |
+
+Use: `skill("requesting-code-review")`.
+
+```
+
+- [ ] **Step 2: Update `## Collaboration`**
+
+Find:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+```
+
+Replace with:
+
+```markdown
+Read `.squad/decisions.md` before starting.
+Read `.squad/superpowers.md` before starting.
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n "superpowers\|requesting-code-review\|## Skills" .squad/agents/oracle/charter.md
+```
+
+Expected: `## Skills` section with requesting-code-review, superpowers.md reference in Collaboration.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .squad/agents/oracle/charter.md
+git commit -m "squad(oracle): wire superpowers skills into charter
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 7: Update Scribe Charter
+
+**Files:**
+- Modify: `.squad/agents/scribe/charter.md`
+
+- [ ] **Step 1: Add `## Skills` section and update `## Work Style`**
+
+Find the `## Work Style` section:
+
+```markdown
+## Work Style
+
+- Read project context and decisions before starting
+- Communicate clearly with team
+- Follow established patterns and conventions
+```
+
+Replace with:
+
+```markdown
+## Work Style
+
+- Read project context and decisions before starting
+- Read `.squad/superpowers.md` before starting
+- Communicate clearly with team
+- Follow established patterns and conventions
+
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `writing-plans` | When tasked with complex documentation or multi-file decision consolidation | Soft — invoke when the scope spans multiple documents or sessions |
+
+Use: `skill("writing-plans")`.
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -n "superpowers\|writing-plans\|## Skills" .squad/agents/scribe/charter.md
+```
+
+Expected: superpowers.md reference in Work Style, `## Skills` section with writing-plans.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .squad/agents/scribe/charter.md
+git commit -m "squad(scribe): wire superpowers skills into charter
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 8: Update Ralph Charter
+
+**Files:**
+- Modify: `.squad/agents/ralph/charter.md`
+
+- [ ] **Step 1: Add `## Skills` section and update `## Work Style`**
+
+Find the `## Work Style` section:
+
+```markdown
+## Work Style
+
+- Read project context and decisions before starting
+- Communicate clearly with team
+- Follow established patterns and conventions
+```
+
+Replace with:
+
+```markdown
+## Work Style
+
+- Read project context and decisions before starting
+- Read `.squad/superpowers.md` before starting
+- Communicate clearly with team
+- Follow established patterns and conventions
+
+## Skills
+
+| Skill | Trigger | Gate |
+|-------|---------|------|
+| `find-skills` | When encountering an unfamiliar task type | Soft — invoke to discover which skill applies |
+
+Use: `skill("find-skills")`.
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -n "superpowers\|find-skills\|## Skills" .squad/agents/ralph/charter.md
+```
+
+Expected: superpowers.md reference in Work Style, `## Skills` section with find-skills.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .squad/agents/ralph/charter.md
+git commit -m "squad(ralph): wire superpowers skills into charter
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Confirm all charters reference `superpowers.md`**
+
+```bash
+grep -l "superpowers" .squad/agents/*/charter.md
+```
+
+Expected: All 7 charter files listed.
+
+- [ ] **Confirm all hard-gate skills appear in `## How I Work` sections**
+
+```bash
+grep -n "hard gate" .squad/agents/*/charter.md
+```
+
+Expected: morpheus (2 lines), trinity (1 line), neo (1 line), tank (1 line).
+
+- [ ] **Confirm `.squad/superpowers.md` exists and has the catalog**
+
+```bash
+grep -c "^|" .squad/superpowers.md
+```
+
+Expected: 10 or more (counts table rows across all three catalog tables).

--- a/docs/superpowers/specs/2026-04-24-squad-superpowers-integration-design.md
+++ b/docs/superpowers/specs/2026-04-24-squad-superpowers-integration-design.md
@@ -1,0 +1,75 @@
+# Squad Superpowers Integration
+
+**Date:** 2026-04-24
+**Status:** Approved
+
+## Problem
+
+The squad agents have well-defined charters for their domains but no guidance on when to invoke superpowers skills. Skills like `test-driven-development`, `brainstorming`, and `requesting-code-review` exist to enforce discipline at key workflow gates, but agents have no mechanism to discover or apply them.
+
+## Approach
+
+Two-part integration:
+
+1. **Shared contract** — `.squad/superpowers.md` lists all available skills, the hard gate rule, and invocation mechanics. All agents read it at session start alongside `.squad/decisions.md`.
+2. **Agent-specific rules** — Each charter gets a `## Skills` section with domain-specific trigger conditions, plus targeted additions to `## How I Work` and `## Collaboration`.
+
+## Shared Contract: `.squad/superpowers.md`
+
+Contains:
+
+- **Hard gate rule** — Check for skills before any action. Even 1% chance means invoke.
+- **Invocation** — Use the `skill` tool (Copilot CLI).
+- **Skills catalog** — All available skills with one-line descriptions and trigger conditions.
+- **Priority rule** — Process skills (brainstorming, test-driven-development) before implementation skills.
+- **Subagent note** — `using-superpowers` is skipped when dispatched as a subagent. All other skills still apply.
+
+## Charter Updates
+
+### Structure of changes per charter
+
+Each charter receives:
+
+1. A new `## Skills` section between `## How I Work` and `## Boundaries` listing skill triggers specific to that agent's domain.
+2. A one-line addition to `## Collaboration`: `Read .squad/superpowers.md before starting.`
+3. Where a skill is a hard gate for a core workflow step, a note is added to the relevant step in `## How I Work`.
+
+### Agent Skill Mappings
+
+| Agent | Skill | Trigger | Gate strength |
+|-------|-------|---------|---------------|
+| Morpheus | `brainstorming` | Before any architecture decision or new feature scoping | Hard |
+| Morpheus | `writing-plans` | Before breaking down complex multi-step work for the team | Soft |
+| Morpheus | `requesting-code-review` | After completing architecture/design review, before declaring done | Hard |
+| Trinity | `test-driven-development` | Before writing any new feature code | Hard |
+| Trinity | `brainstorming` | Before designing complex backend patterns (new pipeline stages, major context rewrites) | Soft |
+| Neo | `test-driven-development` | Before writing any new LiveView or JS code | Hard |
+| Neo | `brainstorming` | Before building new UI flows or components with significant user interaction | Soft |
+| Tank | `test-driven-development` | Invoke at the start of every testing task — this IS Tank's primary workflow | Hard |
+| Oracle | `requesting-code-review` | After completing security audit, before issuing merge/block decision | Hard |
+| Scribe | `writing-plans` | When tasked with complex documentation or multi-file decision consolidation | Soft |
+| Ralph | `find-skills` | When encountering an unfamiliar task type | Soft |
+
+**Gate strength:**
+- **Hard** — Must invoke before proceeding. Skipping is a workflow violation.
+- **Soft** — Invoke when the situation clearly matches. Use judgment for edge cases.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.squad/superpowers.md` | New file — shared skills contract |
+| `.squad/agents/morpheus/charter.md` | Add `## Skills`, update `## Collaboration`, update `## How I Work` |
+| `.squad/agents/trinity/charter.md` | Add `## Skills`, update `## Collaboration`, update `## How I Work` |
+| `.squad/agents/neo/charter.md` | Add `## Skills`, update `## Collaboration`, update `## How I Work` |
+| `.squad/agents/tank/charter.md` | Add `## Skills`, update `## Collaboration`, update `## How I Work` |
+| `.squad/agents/oracle/charter.md` | Add `## Skills`, update `## Collaboration` |
+| `.squad/agents/scribe/charter.md` | Add `## Skills`, update `## Collaboration` |
+| `.squad/agents/ralph/charter.md` | Add `## Skills`, update `## Collaboration` |
+
+## Success Criteria
+
+- Every agent charter explicitly states which skills to invoke and when
+- `.squad/superpowers.md` is a self-contained reference an agent can read cold
+- Hard gate skills appear in the workflow steps where they apply, not just in a standalone section
+- Agents reading `decisions.md` and `superpowers.md` at session start have everything they need to apply skills correctly

--- a/lib/stream_closed_captioner_phoenix/captions_pipeline/translations.ex
+++ b/lib/stream_closed_captioner_phoenix/captions_pipeline/translations.ex
@@ -61,6 +61,10 @@ defmodule StreamClosedCaptionerPhoenix.CaptionsPipeline.Translations do
     to_languages =
       Settings.get_formatted_translate_languages_by_user(user.id) |> Map.keys() |> Enum.sort()
 
-    Azure.perform_translations(from_language, to_languages, text)
+    if FunWithFlags.enabled?(:gemini_translations, for: user) do
+      Gemini.perform_translations(from_language, to_languages, text)
+    else
+      Azure.perform_translations(from_language, to_languages, text)
+    end
   end
 end

--- a/lib/stream_closed_captioner_phoenix/services/gemini.ex
+++ b/lib/stream_closed_captioner_phoenix/services/gemini.ex
@@ -3,7 +3,7 @@ defmodule Gemini do
     do: Application.get_env(:stream_closed_captioner_phoenix, :gemini_cognitive_client)
 
   @spec perform_translations(String.t(), [String.t()], String.t()) ::
-          {:ok, map()} | {:error, term()}
+          {:ok, Azure.Cognitive.Translations.t()} | {:error, term()}
   def perform_translations(from_language, to_languages, text) do
     api_client().translate(from_language, to_languages, text)
   end

--- a/lib/stream_closed_captioner_phoenix/services/gemini.ex
+++ b/lib/stream_closed_captioner_phoenix/services/gemini.ex
@@ -1,0 +1,10 @@
+defmodule Gemini do
+  def api_client,
+    do: Application.get_env(:stream_closed_captioner_phoenix, :gemini_cognitive_client)
+
+  @spec perform_translations(String.t(), [String.t()], String.t()) ::
+          {:ok, Azure.Cognitive.Translations.t()} | {:error, term()}
+  def perform_translations(from_language, to_languages, text) do
+    api_client().translate(from_language, to_languages, text)
+  end
+end

--- a/lib/stream_closed_captioner_phoenix/services/gemini.ex
+++ b/lib/stream_closed_captioner_phoenix/services/gemini.ex
@@ -3,7 +3,7 @@ defmodule Gemini do
     do: Application.get_env(:stream_closed_captioner_phoenix, :gemini_cognitive_client)
 
   @spec perform_translations(String.t(), [String.t()], String.t()) ::
-          {:ok, Azure.Cognitive.Translations.t()} | {:error, term()}
+          {:ok, map()} | {:error, term()}
   def perform_translations(from_language, to_languages, text) do
     api_client().translate(from_language, to_languages, text)
   end

--- a/lib/stream_closed_captioner_phoenix/services/gemini/cognitive.ex
+++ b/lib/stream_closed_captioner_phoenix/services/gemini/cognitive.ex
@@ -1,0 +1,121 @@
+defmodule Gemini.Cognitive do
+  use NewRelic.Tracer
+
+  require Logger
+
+  alias Azure.Cognitive.Translations
+  alias NewRelic.Instrumented.HTTPoison
+
+  @behaviour Gemini.CognitiveProvider
+
+  @model "gemini-2.5-flash-lite"
+  @endpoint "https://generativelanguage.googleapis.com/v1beta/models"
+
+  @response_schema %{
+    type: "OBJECT",
+    properties: %{
+      translations: %{
+        type: "ARRAY",
+        items: %{
+          type: "OBJECT",
+          properties: %{
+            to: %{type: "STRING"},
+            text: %{type: "STRING"}
+          },
+          required: ["to", "text"]
+        }
+      }
+    },
+    required: ["translations"]
+  }
+
+  @impl Gemini.CognitiveProvider
+
+  @trace :translate
+  def translate(from_language \\ "en", to_languages, text)
+      when is_list(to_languages) and is_binary(text) do
+    [from_code | _] = String.split(from_language, "-")
+    filtered_languages = Enum.reject(to_languages, &(&1 == from_code))
+
+    if filtered_languages == [] do
+      {:ok, Translations.new(%{translations: []})}
+    else
+      do_translate(from_language, filtered_languages, text)
+    end
+  end
+
+  defp do_translate(from_language, to_languages, text) do
+    NewRelic.add_attributes(translate: %{from: from_language, to: to_languages, text: text})
+
+    headers = [{"Content-Type", "application/json"}]
+    body = Jason.encode!(build_request_body(from_language, to_languages, text))
+    url = "#{@endpoint}/#{@model}:generateContent?key=#{System.get_env("GEMINI_API_KEY")}"
+
+    case HTTPoison.post(url, body, headers) do
+      {:ok, %{body: raw_body}} ->
+        parse_response_body(raw_body)
+
+      {:error, %{reason: reason}} ->
+        Logger.warning("Gemini API request failed: #{inspect(reason)}")
+        {:error, {:http, reason}}
+    end
+  end
+
+  defp build_request_body(from_language, to_languages, text) do
+    %{
+      contents: [
+        %{
+          parts: [
+            %{text: build_prompt(from_language, to_languages, text)}
+          ]
+        }
+      ],
+      generationConfig: %{
+        responseMimeType: "application/json",
+        responseSchema: @response_schema,
+        temperature: 0
+      }
+    }
+  end
+
+  defp build_prompt(from_language, to_languages, text) do
+    """
+    Translate the text below from language code "#{from_language}" into each of these target language codes: #{Enum.join(to_languages, ", ")}.
+    Respond ONLY with JSON matching the provided schema: an object with a "translations" array, where each entry is {"to": "<language code>", "text": "<translated text>"}. Include exactly one entry per target language, in the same order as the targets. Do not include any entry for the source language. Preserve punctuation and casing.
+
+    Text:
+    #{text}
+    """
+  end
+
+  @doc false
+  def parse_response_body(raw_body) do
+    with {:ok, decoded} <- Jason.decode(raw_body),
+         {:ok, inner_text} <- extract_inner_text(decoded),
+         {:ok, payload} <- Jason.decode(inner_text),
+         %{"translations" => translations} when is_list(translations) <- payload do
+      {:ok, Translations.new(%{translations: translations})}
+    else
+      {:error, %Jason.DecodeError{} = reason} ->
+        Logger.warning("Gemini API response decode failed: #{inspect(reason)}")
+        {:error, {:json_decode, reason}}
+
+      {:error, {:unexpected_json, _} = reason} ->
+        Logger.warning("Gemini API returned unexpected JSON shape: #{inspect(reason)}")
+        {:error, reason}
+
+      other ->
+        Logger.warning("Gemini API returned unexpected JSON shape: #{inspect(other)}")
+        {:error, {:unexpected_json, other}}
+    end
+  end
+
+  defp extract_inner_text(%{"candidates" => [candidate | _]}) do
+    case get_in(candidate, ["content", "parts"]) do
+      [%{"text" => text} | _] when is_binary(text) -> {:ok, text}
+      _ -> {:error, {:unexpected_json, candidate}}
+    end
+  end
+
+  defp extract_inner_text(other), do: {:error, {:unexpected_json, other}}
+end

--- a/lib/stream_closed_captioner_phoenix/services/gemini/cognitive.ex
+++ b/lib/stream_closed_captioner_phoenix/services/gemini/cognitive.ex
@@ -47,9 +47,13 @@ defmodule Gemini.Cognitive do
   defp do_translate(from_language, to_languages, text) do
     NewRelic.add_attributes(translate: %{from: from_language, to: to_languages, text: text})
 
-    headers = [{"Content-Type", "application/json"}]
+    headers = [
+      {"Content-Type", "application/json"},
+      {"x-goog-api-key", System.get_env("GEMINI_API_KEY")}
+    ]
+
     body = Jason.encode!(build_request_body(from_language, to_languages, text))
-    url = "#{@endpoint}/#{@model}:generateContent?key=#{System.get_env("GEMINI_API_KEY")}"
+    url = "#{endpoint()}/#{@model}:generateContent"
 
     case HTTPoison.post(url, body, headers) do
       {:ok, %{body: raw_body}} ->
@@ -118,4 +122,7 @@ defmodule Gemini.Cognitive do
   end
 
   defp extract_inner_text(other), do: {:error, {:unexpected_json, other}}
+
+  defp endpoint,
+    do: Application.get_env(:stream_closed_captioner_phoenix, :gemini_endpoint, @endpoint)
 end

--- a/lib/stream_closed_captioner_phoenix/services/gemini/cognitive_provider.ex
+++ b/lib/stream_closed_captioner_phoenix/services/gemini/cognitive_provider.ex
@@ -1,0 +1,6 @@
+defmodule Gemini.CognitiveProvider do
+  alias Azure.Cognitive.Translations
+
+  @callback translate(String.t(), [String.t()], String.t()) ::
+              {:ok, Translations.t()} | {:error, term()}
+end

--- a/test/stream_closed_captioner_phoenix/captions_pipeline/translations_test.exs
+++ b/test/stream_closed_captioner_phoenix/captions_pipeline/translations_test.exs
@@ -1,5 +1,6 @@
 defmodule StreamClosedCaptionerPhoenix.CaptionsPipeline.TranslationsTest do
-  use StreamClosedCaptionerPhoenix.DataCase, async: true
+  # async: false because FunWithFlags keeps flag state in a shared in-memory cache.
+  use StreamClosedCaptionerPhoenix.DataCase, async: false
 
   import Mox
   import StreamClosedCaptionerPhoenix.Factory
@@ -7,6 +8,12 @@ defmodule StreamClosedCaptionerPhoenix.CaptionsPipeline.TranslationsTest do
   alias StreamClosedCaptionerPhoenix.CaptionsPipeline.Translations
 
   setup :verify_on_exit!
+
+  setup do
+    FunWithFlags.disable(:gemini_translations)
+    on_exit(fn -> FunWithFlags.disable(:gemini_translations) end)
+    :ok
+  end
 
   describe "maybe_translate/3 — no translation needed" do
     test "returns payload unchanged when user has no translate languages configured" do
@@ -148,6 +155,110 @@ defmodule StreamClosedCaptionerPhoenix.CaptionsPipeline.TranslationsTest do
       result = Translations.maybe_translate(payload, :final, user)
 
       assert result.translations == nil
+    end
+  end
+
+  describe "maybe_translate/3 — gemini flag enabled" do
+    test "routes to Gemini when flag is enabled for the user (active debit)" do
+      user =
+        insert(:user,
+          bits_balance: build(:bits_balance, balance: 0),
+          translate_languages: [build(:translate_language, language: "es")]
+        )
+
+      insert(:bits_balance_debit, user: user)
+      FunWithFlags.enable(:gemini_translations, for_actor: user)
+
+      Gemini.MockCognitive
+      |> expect(:translate, fn _from, _to, _text ->
+        {:ok,
+         Azure.Cognitive.Translations.new(%{
+           translations: [%{"text" => "Hola (gemini)", "to" => "es"}]
+         })}
+      end)
+
+      payload = %Twitch.Extension.CaptionsPayload{final: "Hello", interim: "", delay: 0}
+      result = Translations.maybe_translate(payload, :final, user)
+
+      assert result.translations == %{
+               "es" => %Azure.Cognitive.Translation{text: "Hola (gemini)", name: "Spanish"}
+             }
+    end
+
+    test "routes to Gemini on fresh activation when flag is enabled for the user" do
+      user =
+        insert(:user,
+          bits_balance: build(:bits_balance, balance: 500),
+          translate_languages: [build(:translate_language, language: "fr")]
+        )
+
+      FunWithFlags.enable(:gemini_translations, for_actor: user)
+
+      Gemini.MockCognitive
+      |> expect(:translate, fn _from, _to, _text ->
+        {:ok,
+         Azure.Cognitive.Translations.new(%{
+           translations: [%{"text" => "Bonjour", "to" => "fr"}]
+         })}
+      end)
+
+      payload = %Twitch.Extension.CaptionsPayload{final: "Hello", interim: "", delay: 0}
+      result = Translations.maybe_translate(payload, :final, user)
+
+      assert result.translations == %{
+               "fr" => %Azure.Cognitive.Translation{text: "Bonjour", name: "French"}
+             }
+
+      assert %{balance: 0} = StreamClosedCaptionerPhoenix.Bits.get_bits_balance!(user)
+    end
+
+    test "falls back to payload when Gemini returns an error" do
+      user =
+        insert(:user,
+          bits_balance: build(:bits_balance, balance: 0),
+          translate_languages: [build(:translate_language, language: "es")]
+        )
+
+      insert(:bits_balance_debit, user: user)
+      FunWithFlags.enable(:gemini_translations, for_actor: user)
+
+      Gemini.MockCognitive
+      |> expect(:translate, fn _from, _to, _text ->
+        {:error, {:http, :timeout}}
+      end)
+
+      payload = %Twitch.Extension.CaptionsPayload{final: "Hello", interim: "", delay: 0}
+      result = Translations.maybe_translate(payload, :final, user)
+
+      assert result.translations == nil
+    end
+
+    test "still routes to Azure when flag is enabled for a different user" do
+      other_user = insert(:user)
+      FunWithFlags.enable(:gemini_translations, for_actor: other_user)
+
+      user =
+        insert(:user,
+          bits_balance: build(:bits_balance, balance: 0),
+          translate_languages: [build(:translate_language, language: "es")]
+        )
+
+      insert(:bits_balance_debit, user: user)
+
+      Azure.MockCognitive
+      |> expect(:translate, fn _from, _to, _text ->
+        {:ok,
+         Azure.Cognitive.Translations.new(%{
+           translations: [%{"text" => "Hola", "to" => "es"}]
+         })}
+      end)
+
+      payload = %Twitch.Extension.CaptionsPayload{final: "Hello", interim: "", delay: 0}
+      result = Translations.maybe_translate(payload, :final, user)
+
+      assert result.translations == %{
+               "es" => %Azure.Cognitive.Translation{text: "Hola", name: "Spanish"}
+             }
     end
   end
 

--- a/test/stream_closed_captioner_phoenix/services/gemini/cognitive_test.exs
+++ b/test/stream_closed_captioner_phoenix/services/gemini/cognitive_test.exs
@@ -1,0 +1,102 @@
+defmodule Gemini.CognitiveTest do
+  use ExUnit.Case, async: true
+
+  alias Azure.Cognitive.Translation
+  alias Azure.Cognitive.Translations
+
+  describe "parse_response_body/1" do
+    test "parses a well-formed Gemini response into Translations struct keyed by language code" do
+      inner_json =
+        Jason.encode!(%{
+          translations: [
+            %{"to" => "es", "text" => "Hola"},
+            %{"to" => "fr", "text" => "Bonjour"}
+          ]
+        })
+
+      raw_body =
+        Jason.encode!(%{
+          "candidates" => [
+            %{"content" => %{"parts" => [%{"text" => inner_json}]}}
+          ]
+        })
+
+      assert {:ok, %Translations{translations: translations}} =
+               Gemini.Cognitive.parse_response_body(raw_body)
+
+      assert %Translation{text: "Hola", name: "Spanish"} = translations["es"]
+      assert %Translation{text: "Bonjour", name: "French"} = translations["fr"]
+    end
+
+    test "returns :unexpected_json when candidates list is missing" do
+      raw_body = Jason.encode!(%{"promptFeedback" => %{"blockReason" => "SAFETY"}})
+
+      assert {:error, {:unexpected_json, _}} =
+               Gemini.Cognitive.parse_response_body(raw_body)
+    end
+
+    test "returns :unexpected_json when candidates list is empty" do
+      raw_body = Jason.encode!(%{"candidates" => []})
+
+      assert {:error, {:unexpected_json, _}} =
+               Gemini.Cognitive.parse_response_body(raw_body)
+    end
+
+    test "returns :unexpected_json when candidate parts are missing" do
+      raw_body =
+        Jason.encode!(%{
+          "candidates" => [%{"content" => %{"parts" => []}}]
+        })
+
+      assert {:error, {:unexpected_json, _}} =
+               Gemini.Cognitive.parse_response_body(raw_body)
+    end
+
+    test "returns :json_decode when inner text is not valid JSON" do
+      raw_body =
+        Jason.encode!(%{
+          "candidates" => [
+            %{"content" => %{"parts" => [%{"text" => "not json at all"}]}}
+          ]
+        })
+
+      assert {:error, {:json_decode, %Jason.DecodeError{}}} =
+               Gemini.Cognitive.parse_response_body(raw_body)
+    end
+
+    test "returns :json_decode when outer body is not valid JSON" do
+      assert {:error, {:json_decode, %Jason.DecodeError{}}} =
+               Gemini.Cognitive.parse_response_body("<html>oops</html>")
+    end
+
+    test "returns :unexpected_json when inner payload is missing translations key" do
+      inner_json = Jason.encode!(%{"unexpected" => "shape"})
+
+      raw_body =
+        Jason.encode!(%{
+          "candidates" => [
+            %{"content" => %{"parts" => [%{"text" => inner_json}]}}
+          ]
+        })
+
+      assert {:error, {:unexpected_json, _}} =
+               Gemini.Cognitive.parse_response_body(raw_body)
+    end
+  end
+
+  describe "translate/3 — short-circuits" do
+    test "returns empty translations struct when to_languages filter yields nothing" do
+      assert {:ok, %Translations{translations: translations}} =
+               Gemini.Cognitive.translate("en", ["en"], "Hello")
+
+      assert translations == %{}
+    end
+
+    test "returns empty translations struct for empty to_languages" do
+      assert {:ok, %Translations{translations: translations}} =
+               Gemini.Cognitive.translate("en", [], "Hello")
+
+      assert translations == %{}
+    end
+  end
+end

--- a/test/stream_closed_captioner_phoenix/services/gemini/cognitive_test.exs
+++ b/test/stream_closed_captioner_phoenix/services/gemini/cognitive_test.exs
@@ -1,5 +1,7 @@
 defmodule Gemini.CognitiveTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
 
   alias Azure.Cognitive.Translation
   alias Azure.Cognitive.Translations
@@ -97,6 +99,71 @@ defmodule Gemini.CognitiveTest do
                Gemini.Cognitive.translate("en", [], "Hello")
 
       assert translations == %{}
+    end
+  end
+
+  describe "do_translate/3 — HTTP" do
+    setup do
+      bypass = Bypass.open()
+
+      System.put_env("GEMINI_API_KEY", "test-api-key")
+
+      Application.put_env(
+        :stream_closed_captioner_phoenix,
+        :gemini_endpoint,
+        "http://localhost:#{bypass.port}"
+      )
+
+      on_exit(fn ->
+        System.delete_env("GEMINI_API_KEY")
+        Application.delete_env(:stream_closed_captioner_phoenix, :gemini_endpoint)
+      end)
+
+      {:ok, bypass: bypass}
+    end
+
+    test "returns translations struct and sends API key as header, not query param", %{
+      bypass: bypass
+    } do
+      response_body =
+        Jason.encode!(%{
+          "candidates" => [
+            %{
+              "content" => %{
+                "parts" => [
+                  %{
+                    "text" =>
+                      Jason.encode!(%{
+                        "translations" => [%{"text" => "Hola", "to" => "es"}]
+                      })
+                  }
+                ]
+              }
+            }
+          ]
+        })
+
+      Bypass.expect_once(bypass, "POST", "/gemini-2.5-flash-lite:generateContent", fn conn ->
+        [api_key_header] = get_req_header(conn, "x-goog-api-key")
+        assert api_key_header == "test-api-key"
+        refute conn.query_string =~ "key="
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(200, response_body)
+      end)
+
+      assert {:ok, %Translations{translations: translations}} =
+               Gemini.Cognitive.translate("en", ["es"], "Hello")
+
+      assert %{"es" => %Translation{text: "Hola"}} = translations
+    end
+
+    test "returns error tuple when server is unreachable", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      assert {:error, {:http, :econnrefused}} =
+               Gemini.Cognitive.translate("en", ["es"], "Hello")
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,5 +5,6 @@ Ecto.Adapters.SQL.Sandbox.mode(StreamClosedCaptionerPhoenix.Repo, :manual)
 
 # Mocks services out using their provider
 Mox.defmock(Azure.MockCognitive, for: Azure.CognitiveProvider)
+Mox.defmock(Gemini.MockCognitive, for: Gemini.CognitiveProvider)
 Mox.defmock(Twitch.MockExtension, for: Twitch.ExtensionProvider)
 Mox.defmock(Twitch.MockHelix, for: Twitch.HelixProvider)


### PR DESCRIPTION
Introduce Gemini.Cognitive as an alternative to Azure.Cognitive for caption
translation, gated by the :gemini_translations FunWithFlags flag (default
OFF). Azure remains the default path so the flag can be toggled per-user or
globally via /feature-flags without a redeploy if Gemini misbehaves.

The new module reuses Azure.Cognitive.Translations/Translation result structs
so nothing downstream of the translator has to change.