### PR TITLE
Fix infinite extension status polling loop in Twitch controller

### DIFF
--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -9,7 +9,8 @@ Agent Scribe initialized and ready for work.
 
 ## Recent Updates
 
-📌 Team initialized on 2026-04-19
+📌 Team initialized on 2026-04-19  
+📌 **2026-04-21:** Merged Pragmatic Programmer directive into decisions.md; inbox cleared
 
 ## Learnings
 

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -9,7 +9,7 @@ Agent Scribe initialized and ready for work.
 
 ## Recent Updates
 
-📌 Team initialized on 2026-04-19  
+📌 Team initialized on 2026-04-19
 📌 **2026-04-21:** Merged Pragmatic Programmer directive into decisions.md; inbox cleared
 
 ## Learnings

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -4,8 +4,8 @@
 
 ### Pragmatic Programmer Methodologies — Team Standard
 
-**By:** Erik Guzman (via Copilot)  
-**Date:** 2026-04-21  
+**By:** Erik Guzman (via Copilot)
+**Date:** 2026-04-21
 **Category:** Process & Philosophy
 
 All team members should read and follow *The Pragmatic Programmer* methodologies as core development practices for this project.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,7 +2,27 @@
 
 ## Active Decisions
 
-No decisions recorded yet.
+### Pragmatic Programmer Methodologies — Team Standard
+
+**By:** Erik Guzman (via Copilot)  
+**Date:** 2026-04-21  
+**Category:** Process & Philosophy
+
+All team members should read and follow *The Pragmatic Programmer* methodologies as core development practices for this project.
+
+**Key Principles:**
+- **DRY (Don't Repeat Yourself)** — eliminate duplication in code and logic
+- **Fail Fast & Handle Errors Gracefully** — explicit error messaging over silent failures
+- **Invest in Tooling** — leverage linting, testing, automation, CI/CD effectively
+- **Refactor Ruthlessly** — continuously improve code structure and clarity
+- **Know Your Domain** — master Twitch API, Phoenix patterns, Elixir idioms
+- **Communicate Clearly** — code should be readable; tests should document behavior
+- **Automate Tests** — catch issues early; prioritize test coverage
+- **Estimate Carefully** — be realistic about complexity and dependencies
+
+**Impact on Review:** Code reviews evaluate adherence to these principles. PRs that violate DRY, fail to handle errors gracefully, or lack clarity are sent back for refinement.
+
+**Status:** ✅ Adopted as team standard
 
 ## Governance
 

--- a/assets/js/controllers/twitch_controller.js
+++ b/assets/js/controllers/twitch_controller.js
@@ -1,40 +1,79 @@
-import debugLogger from "debug"
-
+import { isNil } from "ramda"
 import { ApplicationController } from "stimulus-use"
+import * as workerTimers from "worker-timers"
 
-import { isNil, isEmpty } from "ramda"
 import { appClient } from "../service/app-client"
 import { GET_ME } from "../utils/graphql"
-import * as workerTimers from 'worker-timers';
-
-const debug = debugLogger("cc:obs-controller")
 
 export default class extends ApplicationController {
   static targets = ["offSwitch", "onSwitch", "errorMarker", "errorMessage"]
 
+  static values = {
+    maxRetryAttempts: { type: Number, default: 10 },
+    retryBaseDelayMs: { type: Number, default: 2000 },
+    maxRetryDelayMs: { type: Number, default: 30_000 },
+  }
+
   connect() {
     this.enabled = false
     this.extensionInstalled = false
+    this.retryAttempts = 0
+    this.retryTimeout = null
 
     this.fetchExtensionStatus()
   }
 
   fetchExtensionStatus = () => {
-    appClient.request(GET_ME).then(({ me }) => {
-      this.extensionInstalled = me.extensionInstalled
+    appClient.request(GET_ME)
+      .then(({ me }) => {
+        this.extensionInstalled = !isNil(me) && me.extensionInstalled
 
-      if (this.extensionInstalled) {
-        this.clearErrorMessage()
-        this.enableExtension()
-      } else {
+        if (this.extensionInstalled) {
+          this.retryAttempts = 0
+          this.clearRetryTimeout()
+          this.clearErrorMessage()
+          return this.enableExtension()
+        } 
+          this.disableExtension()
+          this.displayErrorMessage("You do not have the Stream Closed Captioner Extension installed, please visit the 'Quick Starts Instructions' to learn how.")
+          return this.scheduleExtensionStatusRetry()
+        
+      })
+      .catch(() => {
         this.disableExtension()
-        this.displayErrorMessage("You do not have the Stream Closed Captioner Extension installed, please visit the 'Quick Starts Instructions' to learn how.")
-        workerTimers.setTimeout(this.fetchExtensionStatus, 2000)
-      }
-    })
+        this.displayErrorMessage("Could not verify Twitch extension status. Check your connection and try again.")
+        return this.scheduleExtensionStatusRetry()
+      })
   }
 
-  disconnect() { }
+  disconnect() {
+    this.clearRetryTimeout()
+  }
+
+  scheduleExtensionStatusRetry() {
+    if (this.retryAttempts >= this.maxRetryAttemptsValue) {
+      return
+    }
+
+    this.clearRetryTimeout()
+
+    const delay = Math.min(
+      this.retryBaseDelayMsValue * 2 ** this.retryAttempts,
+      this.maxRetryDelayMsValue,
+    )
+
+    this.retryAttempts += 1
+    this.retryTimeout = workerTimers.setTimeout(this.fetchExtensionStatus, delay)
+  }
+
+  clearRetryTimeout() {
+    if (isNil(this.retryTimeout)) {
+      return
+    }
+
+    workerTimers.clearTimeout(this.retryTimeout)
+    this.retryTimeout = null
+  }
 
   toggleOn = () => {
     if (!this.extensionInstalled) return
@@ -49,12 +88,12 @@ export default class extends ApplicationController {
 
   clearErrorMessage() {
     this.errorMessageTarget.classList.add("hidden")
-    this.errorMessageTarget.innerText = ""
+    this.errorMessageTarget.textContent = ""
   }
 
   displayErrorMessage(text) {
     this.errorMessageTarget.classList.remove("hidden")
-    this.errorMessageTarget.innerText = text
+    this.errorMessageTarget.textContent = text
   }
 
   enableExtension() {

--- a/assets/js/controllers/twitch_controller.js
+++ b/assets/js/controllers/twitch_controller.js
@@ -17,7 +17,7 @@ export default class extends ApplicationController {
   connect() {
     this.enabled = false
     this.extensionInstalled = false
-    this.retryAttempts = 0
+    this.attemptCount = 1
     this.retryTimeout = null
 
     this.fetchExtensionStatus()
@@ -29,7 +29,7 @@ export default class extends ApplicationController {
         this.extensionInstalled = !isNil(me) && me.extensionInstalled
 
         if (this.extensionInstalled) {
-          this.retryAttempts = 0
+          this.attemptCount = 0
           this.clearRetryTimeout()
           this.clearErrorMessage()
           return this.enableExtension()
@@ -51,18 +51,21 @@ export default class extends ApplicationController {
   }
 
   scheduleExtensionStatusRetry() {
-    if (this.retryAttempts >= this.maxRetryAttemptsValue) {
+    if (this.attemptCount >= this.maxRetryAttemptsValue) {
+      this.displayErrorMessage(
+        "Unable to verify extension status after multiple attempts. Please refresh the page after installing the extension."
+      )
       return
     }
 
     this.clearRetryTimeout()
 
     const delay = Math.min(
-      this.retryBaseDelayMsValue * 2 ** this.retryAttempts,
+      this.retryBaseDelayMsValue * 2 ** (this.attemptCount - 1),
       this.maxRetryDelayMsValue,
     )
 
-    this.retryAttempts += 1
+    this.attemptCount += 1
     this.retryTimeout = workerTimers.setTimeout(this.fetchExtensionStatus, delay)
   }
 

--- a/assets/js/controllers/twitch_controller.js
+++ b/assets/js/controllers/twitch_controller.js
@@ -33,11 +33,11 @@ export default class extends ApplicationController {
           this.clearRetryTimeout()
           this.clearErrorMessage()
           return this.enableExtension()
-        } 
-          this.disableExtension()
-          this.displayErrorMessage("You do not have the Stream Closed Captioner Extension installed, please visit the 'Quick Starts Instructions' to learn how.")
-          return this.scheduleExtensionStatusRetry()
-        
+        }
+        this.disableExtension()
+        this.displayErrorMessage("You do not have the Stream Closed Captioner Extension installed, please visit the 'Quick Starts Instructions' to learn how.")
+        return this.scheduleExtensionStatusRetry()
+
       })
       .catch(() => {
         this.disableExtension()


### PR DESCRIPTION
## Summary\n- cap extension status polling attempts in the Twitch Stimulus controller\n- add exponential backoff with a max delay\n- clear pending retry timers on disconnect and before scheduling\n- handle request failures with user-visible feedback\n- preserve immediate success behavior when extension is installed\n\n## Validation\n- npx eslint js/controllers/twitch_controller.js\n\nCloses #276