### PR TITLE
#289 naive datetime debit fix

### DIFF
--- a/.squad/agents/morpheus/charter.md
+++ b/.squad/agents/morpheus/charter.md
@@ -30,6 +30,7 @@
 | Skill | Trigger | Gate |
 |-------|---------|------|
 | `brainstorming` | Before any architecture decision, feature scoping, design work | **Hard** — must invoke before proceeding |
+| `subagent-driven-development` | Before any implementation task Morpheus directly executes | **Hard** — must invoke before writing code |
 | `writing-plans` | Before break down complex multi-step work for team | Soft — invoke when scope multi-file or multi-session |
 | `requesting-code-review` | After architecture/design review done, before declaring done | **Hard** — must invoke before proceeding |
 

--- a/.squad/agents/neo/charter.md
+++ b/.squad/agents/neo/charter.md
@@ -33,9 +33,10 @@
 | Skill | Trigger | Gate |
 |-------|---------|------|
 | `test-driven-development` | Before any new LiveView/JS code | **Hard** — must invoke before implementation |
+| `subagent-driven-development` | Before any implementation task | **Hard** — must invoke before writing code; drives execution strategy |
 | `brainstorming` | Before new UI flows or components with big user interaction | Soft — invoke when UX design non-obvious |
 
-Use: `skill("test-driven-development")`, `skill("brainstorming")`.
+Use: `skill("test-driven-development")`, `skill("subagent-driven-development")`, `skill("brainstorming")`.
 
 ## Boundaries
 

--- a/.squad/agents/tank/charter.md
+++ b/.squad/agents/tank/charter.md
@@ -35,8 +35,9 @@
 | Skill | Trigger | Gate |
 |-------|---------|------|
 | `test-driven-development` | At start every testing task | **Hard** — skill IS Tank primary workflow; always invoke first |
+| `subagent-driven-development` | Before any implementation task (writing test code) | **Hard** — must invoke before writing test code; drives execution strategy |
 
-Use: `skill("test-driven-development")`.
+Use: `skill("test-driven-development")`, `skill("subagent-driven-development")`.
 
 ## Boundaries
 

--- a/.squad/agents/trinity/charter.md
+++ b/.squad/agents/trinity/charter.md
@@ -34,9 +34,10 @@
 | Skill | Trigger | Gate |
 |-------|---------|------|
 | `test-driven-development` | Before any new feature code | **Hard** — must invoke before implementation |
+| `subagent-driven-development` | Before any implementation task | **Hard** — must invoke before writing code; drives execution strategy |
 | `brainstorming` | Before complex backend patterns (new pipeline stages, major context rewrites) | Soft — invoke when design non-obvious |
 
-Use: `skill("test-driven-development")`, `skill("brainstorming")`.
+Use: `skill("test-driven-development")`, `skill("subagent-driven-development")`, `skill("brainstorming")`.
 
 ## Boundaries
 

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -179,3 +179,13 @@ Facade declares two explicit delegations (1-arity + 2-arity) instead `\\` syntax
 All squad agents MUST communicate caveman mode. Ultra-compressed speak: drop articles/filler/hedging. Fragments OK. Technical terms/code/URLs/paths preserved. Cuts token ~75%.
 
 User req. Enforce via skill invoke.
+
+---
+
+## 2026-04-26T18:35:22Z — Subagent-Driven Development Hard Gate
+
+**By:** Erik Guzman (User) | **Status:** Active
+
+All team members must use `subagent-driven-development` skill for implementation tasks — hard gate, same weight as `test-driven-development`.
+
+User request. Ensures implementation always broken into sub-agent-driven steps rather than monolithic single-agent execution. Charters updated: Trinity, Tank, Neo, Morpheus.

--- a/lib/stream_closed_captioner_phoenix/bits/bits_balance_debit_queries.ex
+++ b/lib/stream_closed_captioner_phoenix/bits/bits_balance_debit_queries.ex
@@ -1,8 +1,6 @@
 defmodule StreamClosedCaptionerPhoenix.Bits.BitsBalanceDebitQueries do
   import Ecto.Query, warn: false
 
-  @seconds_in_hours 3600
-
   alias StreamClosedCaptionerPhoenix.Bits.BitsBalanceDebit
 
   def all(query \\ base()), do: query
@@ -18,20 +16,8 @@ defmodule StreamClosedCaptionerPhoenix.Bits.BitsBalanceDebitQueries do
   end
 
   def less_than_one_day_ago(query \\ base()) do
-    one_day_ago = NaiveDateTime.utc_now() |> NaiveDateTime.add(@seconds_in_hours * -24)
-    # set seconds to 0
-    one_day_ago =
-      NaiveDateTime.new!(
-        one_day_ago.year,
-        one_day_ago.month,
-        one_day_ago.day,
-        one_day_ago.hour,
-        one_day_ago.minute,
-        0
-      )
-
     query
-    |> where([bits_balance_debit], bits_balance_debit.created_at >= ^one_day_ago)
+    |> where([bits_balance_debit], bits_balance_debit.created_at >= fragment("NOW() - INTERVAL '24 hours'"))
   end
 
   defp base do

--- a/lib/stream_closed_captioner_phoenix/bits/bits_balance_debit_queries.ex
+++ b/lib/stream_closed_captioner_phoenix/bits/bits_balance_debit_queries.ex
@@ -17,7 +17,7 @@ defmodule StreamClosedCaptionerPhoenix.Bits.BitsBalanceDebitQueries do
 
   def less_than_one_day_ago(query \\ base()) do
     query
-    |> where([bits_balance_debit], bits_balance_debit.created_at >= fragment("NOW() - INTERVAL '24 hours'"))
+    |> where([bits_balance_debit], bits_balance_debit.created_at >= fragment("(NOW() AT TIME ZONE 'UTC') - INTERVAL '24 hours'"))
   end
 
   defp base do

--- a/test/stream_closed_captioner_phoenix/bits_test.exs
+++ b/test/stream_closed_captioner_phoenix/bits_test.exs
@@ -127,6 +127,54 @@ defmodule StreamClosedCaptionerPhoenix.BitsTest do
 
       refute Bits.get_user_active_debit(bits_balance_debit.user_id)
     end
+
+    # --- 24h boundary tests (issue #289) ---
+    #
+    # We update `created_at` via raw SQL using the DB's own NOW() so that the fixture
+    # timestamps are in the same timezone frame as the query's `NOW() - INTERVAL '24 hours'`
+    # expression. Using Elixir's NaiveDateTime.utc_now() would introduce UTC-vs-session-
+    # timezone drift and make these tests flaky on non-UTC database servers.
+
+    test "get_user_active_debit/1 returns a debit created 23h 59m ago (just inside the 24h window)" do
+      bits_balance_debit = insert(:bits_balance_debit)
+
+      Repo.query!(
+        "UPDATE bits_balance_debits SET created_at = (NOW() - INTERVAL '23 hours 59 minutes')::timestamp WHERE id = $1",
+        [bits_balance_debit.id]
+      )
+
+      assert Bits.get_user_active_debit(bits_balance_debit.user_id)
+    end
+
+    test "get_user_active_debit/1 does not return a debit created 24h 1m ago (just outside the 24h window)" do
+      # The original bug (NaiveDateTime seconds-zeroing) widened the window by up to 59s,
+      # so a debit at 24h+1m ago could still be returned. Trinity's SQL-interval fix closes
+      # this gap by using an exact DB-native interval comparison.
+      bits_balance_debit = insert(:bits_balance_debit)
+
+      Repo.query!(
+        "UPDATE bits_balance_debits SET created_at = (NOW() - INTERVAL '24 hours 1 minute')::timestamp WHERE id = $1",
+        [bits_balance_debit.id]
+      )
+
+      refute Bits.get_user_active_debit(bits_balance_debit.user_id)
+    end
+
+    test "get_user_active_debit/1 does not return a debit created 25h ago (well outside the 24h window)" do
+      bits_balance_debit = insert(:bits_balance_debit)
+
+      Repo.query!(
+        "UPDATE bits_balance_debits SET created_at = (NOW() - INTERVAL '25 hours')::timestamp WHERE id = $1",
+        [bits_balance_debit.id]
+      )
+
+      refute Bits.get_user_active_debit(bits_balance_debit.user_id)
+    end
+
+    # Boundary note — exactly 24h ago:
+    # The query uses `>=`, so a record created at precisely NOW() - 24h is included.
+    # Testing this microsecond edge is inherently racy; the three tests above (23h59m,
+    # 24h+1m, 25h) provide sufficient coverage of the boundary on both sides.
   end
 
   describe "bits_balances" do

--- a/test/stream_closed_captioner_phoenix/bits_test.exs
+++ b/test/stream_closed_captioner_phoenix/bits_test.exs
@@ -147,8 +147,8 @@ defmodule StreamClosedCaptionerPhoenix.BitsTest do
     end
 
     test "get_user_active_debit/1 does not return a debit created 24h 1m ago (just outside the 24h window)" do
-      # so a debit at 24h+1m ago could still be returned. This exact DB-native interval
-      # comparison closes that gap.
+      # The DB-native interval comparison is exact: a debit at 24h+1m ago falls
+      # outside the window and must not be returned.
       bits_balance_debit = insert(:bits_balance_debit)
 
       Repo.query!(

--- a/test/stream_closed_captioner_phoenix/bits_test.exs
+++ b/test/stream_closed_captioner_phoenix/bits_test.exs
@@ -148,8 +148,8 @@ defmodule StreamClosedCaptionerPhoenix.BitsTest do
 
     test "get_user_active_debit/1 does not return a debit created 24h 1m ago (just outside the 24h window)" do
       # The original bug (NaiveDateTime seconds-zeroing) widened the window by up to 59s,
-      # so a debit at 24h+1m ago could still be returned. Trinity's SQL-interval fix closes
-      # this gap by using an exact DB-native interval comparison.
+      # so a debit at 24h+1m ago could still be returned. This exact DB-native interval
+      # comparison closes that gap.
       bits_balance_debit = insert(:bits_balance_debit)
 
       Repo.query!(

--- a/test/stream_closed_captioner_phoenix/bits_test.exs
+++ b/test/stream_closed_captioner_phoenix/bits_test.exs
@@ -130,16 +130,16 @@ defmodule StreamClosedCaptionerPhoenix.BitsTest do
 
     # --- 24h boundary tests (issue #289) ---
     #
-    # We update `created_at` via raw SQL using the DB's own NOW() so that the fixture
-    # timestamps are in the same timezone frame as the query's `NOW() - INTERVAL '24 hours'`
-    # expression. Using Elixir's NaiveDateTime.utc_now() would introduce UTC-vs-session-
-    # timezone drift and make these tests flaky on non-UTC database servers.
+    # We update `created_at` via raw SQL using `NOW() AT TIME ZONE 'UTC'` so that the fixture
+    # timestamps match the UTC-normalized reference frame used by the query's
+    # `(NOW() AT TIME ZONE 'UTC') - INTERVAL '24 hours'` expression. This avoids
+    # drift on non-UTC database sessions.
 
     test "get_user_active_debit/1 returns a debit created 23h 59m ago (just inside the 24h window)" do
       bits_balance_debit = insert(:bits_balance_debit)
 
       Repo.query!(
-        "UPDATE bits_balance_debits SET created_at = (NOW() - INTERVAL '23 hours 59 minutes')::timestamp WHERE id = $1",
+        "UPDATE bits_balance_debits SET created_at = (NOW() AT TIME ZONE 'UTC') - INTERVAL '23 hours 59 minutes' WHERE id = $1",
         [bits_balance_debit.id]
       )
 
@@ -147,13 +147,12 @@ defmodule StreamClosedCaptionerPhoenix.BitsTest do
     end
 
     test "get_user_active_debit/1 does not return a debit created 24h 1m ago (just outside the 24h window)" do
-      # The original bug (NaiveDateTime seconds-zeroing) widened the window by up to 59s,
       # so a debit at 24h+1m ago could still be returned. This exact DB-native interval
       # comparison closes that gap.
       bits_balance_debit = insert(:bits_balance_debit)
 
       Repo.query!(
-        "UPDATE bits_balance_debits SET created_at = (NOW() - INTERVAL '24 hours 1 minute')::timestamp WHERE id = $1",
+        "UPDATE bits_balance_debits SET created_at = (NOW() AT TIME ZONE 'UTC') - INTERVAL '24 hours 1 minute' WHERE id = $1",
         [bits_balance_debit.id]
       )
 
@@ -164,7 +163,7 @@ defmodule StreamClosedCaptionerPhoenix.BitsTest do
       bits_balance_debit = insert(:bits_balance_debit)
 
       Repo.query!(
-        "UPDATE bits_balance_debits SET created_at = (NOW() - INTERVAL '25 hours')::timestamp WHERE id = $1",
+        "UPDATE bits_balance_debits SET created_at = (NOW() AT TIME ZONE 'UTC') - INTERVAL '25 hours' WHERE id = $1",
         [bits_balance_debit.id]
       )
 


### PR DESCRIPTION
This pull request introduces a critical fix to the 24-hour window logic for fetching active bits balance debits, ensuring precise and timezone-safe interval comparisons by moving to a database-native SQL interval. It also adds robust boundary tests to prevent regression and updates agent charters and decision records to require the new `subagent-driven-development` skill as a hard gate for all implementation tasks.

**Bits debit 24-hour window logic and tests:**

* Refactored `less_than_one_day_ago/1` in `bits_balance_debit_queries.ex` to use a database-native SQL interval (`NOW() - INTERVAL '24 hours'`) instead of Elixir-side time math, eliminating potential timezone drift and off-by-seconds errors.
* Added comprehensive boundary tests to `bits_test.exs` to verify correct inclusion/exclusion of debits at 23h59m, 24h01m, and 25h intervals, ensuring the 24-hour window logic is precise and robust.

**Agent charter and process updates:**

* Updated all agent charters (`trinity`, `tank`, `neo`, `morpheus`) to add `subagent-driven-development` as a required skill before any implementation task, making it a hard gate similar to test-driven development. [[1]](diffhunk://#diff-a7b020143616a494e821f7d59aa46c4f6aaee4d6b476ababfbd2781644d2f61aR37-R40) [[2]](diffhunk://#diff-08b0907a5375382f2fcbc43bdb3cb2ecf5ffa47a74408b387719f788b57b2683R38-R40) [[3]](diffhunk://#diff-ff6a235aaccae46f0f50359bebd85d2071e04e4645fc933c97c93a15adced1dfR36-R39) [[4]](diffhunk://#diff-e94064baae3353292c897b0ff44ebfef3585f697563108488815a766a67f8e05R33)
* Recorded the new process requirement in `.squad/decisions.md`, establishing `subagent-driven-development` as a mandatory step for all implementation work.

**Other:**

* Removed an unused constant (`@seconds_in_hours`) from `bits_balance_debit_queries.ex`.

Resolves #289 