### PR TITLE
Reduce Twitch and announcements latency

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,7 +22,8 @@ config :stream_closed_captioner_phoenix, StreamClosedCaptionerPhoenix.Cache,
   gc_cleanup_max_timeout: :timer.minutes(10)
 
 config :stream_closed_captioner_phoenix,
-  ecto_repos: [StreamClosedCaptionerPhoenix.Repo]
+  ecto_repos: [StreamClosedCaptionerPhoenix.Repo],
+  notion_database_client: Notion.Database
 
 # Configures the endpoint
 config :stream_closed_captioner_phoenix, StreamClosedCaptionerPhoenixWeb.Endpoint,
@@ -110,7 +111,7 @@ config :phoenix_meta_tags,
 config :stream_closed_captioner_phoenix, Oban,
   repo: StreamClosedCaptionerPhoenix.Repo,
   plugins: [Oban.Plugins.Pruner, Oban.Plugins.Lifeline, Oban.Plugins.Reindexer],
-  queues: [default: 10, events: 10]
+  queues: [default: 10, events: 10, chat_reminders: 2]
 
 config :stream_closed_captioner_phoenix,
   twitch_client_secret: System.get_env("TWITCH_CLIENT_SECRET")

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,8 +33,10 @@ config :stream_closed_captioner_phoenix, StreamClosedCaptionerPhoenix.Mailer,
 
 config :stream_closed_captioner_phoenix, twitch_extension_client: Twitch.MockExtension
 config :stream_closed_captioner_phoenix, twitch_helix_client: Twitch.MockHelix
+config :stream_closed_captioner_phoenix, twitch_oauth_client: Twitch.MockOauth
 config :stream_closed_captioner_phoenix, azure_cognitive_client: Azure.MockCognitive
 config :stream_closed_captioner_phoenix, gemini_cognitive_client: Gemini.MockCognitive
+config :stream_closed_captioner_phoenix, notion_database_client: Notion.MockDatabase
 
 config :stream_closed_captioner_phoenix, Oban, testing: :manual
 

--- a/lib/stream_closed_captioner_phoenix/announcements.ex
+++ b/lib/stream_closed_captioner_phoenix/announcements.ex
@@ -1,0 +1,58 @@
+defmodule StreamClosedCaptionerPhoenix.Announcements do
+  @moduledoc """
+  Context for Notion-backed announcement pages.
+
+  Results are cached for a short TTL so that repeated page renders do not hit
+  the Notion API on every request. Errors and empty responses are never cached
+  so that a transient Notion outage does not lock the page into a stale empty
+  state across the full TTL window.
+  """
+
+  alias StreamClosedCaptionerPhoenix.Cache
+
+  @notion_db_id "8f9f6076e708455fbb263b3ba9ca48db"
+  @cache_key :notion_announcements_pages
+  @cache_ttl :timer.minutes(5)
+
+  @doc """
+  Returns the list of announcement pages from the Notion database.
+
+  Results are served from cache when available. On a cache miss the Notion API
+  is queried; successful results are stored with a #{div(@cache_ttl, 60_000)}-minute
+  TTL. If Notion returns an error or no `"results"` key, an empty list is
+  returned and nothing is written to cache (so the next request will retry).
+  """
+  @spec list_announcement_pages() :: list(map())
+  def list_announcement_pages do
+    case Cache.get(@cache_key) do
+      nil -> fetch_and_cache()
+      pages -> pages
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helpers
+  # ---------------------------------------------------------------------------
+
+  defp fetch_and_cache do
+    case notion_client().query_database(@notion_db_id, %{}) do
+      {:ok, %{"results" => [_ | _] = pages}} ->
+        Cache.put(@cache_key, pages, ttl: @cache_ttl)
+        pages
+
+      {:ok, _} ->
+        []
+
+      _error ->
+        []
+    end
+  end
+
+  defp notion_client do
+    Application.get_env(
+      :stream_closed_captioner_phoenix,
+      :notion_database_client,
+      Notion.Database
+    )
+  end
+end

--- a/lib/stream_closed_captioner_phoenix/jobs/send_chat_reminder.ex
+++ b/lib/stream_closed_captioner_phoenix/jobs/send_chat_reminder.ex
@@ -1,5 +1,12 @@
 defmodule StreamClosedCaptionerPhoenix.Jobs.SendChatReminder do
-  use Oban.Worker, queue: :default
+  use Oban.Worker,
+    queue: :chat_reminders,
+    max_attempts: 3,
+    unique: [
+      period: 300,
+      fields: [:args, :queue],
+      states: [:available, :scheduled, :executing]
+    ]
 
   # %{broadcaster_user_id: "talk2megooseman", broadcaster_user_login: "talk2megooseman"} |> StreamClosedCaptionerPhoenix.Jobs.SendChatReminder.new(schedule_in: 10) |> Oban.insert()
 
@@ -12,7 +19,7 @@ defmodule StreamClosedCaptionerPhoenix.Jobs.SendChatReminder do
         errors: errors
       }) do
     if Enum.any?(errors) do
-      :cancel
+      {:cancel, :prior_errors}
     else
       if !StreamClosedCaptionerPhoenixWeb.UserTracker.channel_active?(broadcaster_user_id) do
         Twitch.send_extension_chat_message(

--- a/lib/stream_closed_captioner_phoenix/services/notion/database.ex
+++ b/lib/stream_closed_captioner_phoenix/services/notion/database.ex
@@ -2,6 +2,8 @@ defmodule Notion.Database do
   @moduledoc """
   Simple API wrapper for Notion API
   """
+  @behaviour Notion.DatabaseProvider
+
   import Notion.Base
 
   @doc """
@@ -69,5 +71,6 @@ defmodule Notion.Database do
       ]
     }}
   """
+  @impl Notion.DatabaseProvider
   def query_database(database_id, body \\ %{}), do: post("databases/#{database_id}/query", body)
 end

--- a/lib/stream_closed_captioner_phoenix/services/notion/database_provider.ex
+++ b/lib/stream_closed_captioner_phoenix/services/notion/database_provider.ex
@@ -1,0 +1,11 @@
+defmodule Notion.DatabaseProvider do
+  @moduledoc """
+  Behaviour for Notion database operations.
+
+  Allows real and mock implementations to be swapped via application config,
+  following the same provider pattern used throughout this project.
+  """
+
+  @callback query_database(database_id :: String.t(), body :: map()) ::
+              {:ok, map()} | {:error, term()}
+end

--- a/lib/stream_closed_captioner_phoenix/services/twitch.ex
+++ b/lib/stream_closed_captioner_phoenix/services/twitch.ex
@@ -6,8 +6,12 @@ defmodule Twitch do
 
   @extension_id "h1ekceo16erc49snp0sine3k9ccbh9"
 
+  # TTL matches the original commented-out value (5 minutes).
+  @cache_ttl :timer.minutes(5)
+
   require Logger
 
+  alias StreamClosedCaptionerPhoenix.Cache
   alias Twitch.{Extension, Jwt, Oauth}
 
   @doc """
@@ -22,6 +26,22 @@ defmodule Twitch do
   @spec helix_api_client :: Twitch.HelixProvider
   def helix_api_client,
     do: Application.get_env(:stream_closed_captioner_phoenix, :twitch_helix_client)
+
+  @doc """
+  Returns the configured OAuth client module.
+
+  Defaults to `Twitch.Oauth` in production; override via application config
+  (e.g. `config :stream_closed_captioner_phoenix, twitch_oauth_client: Twitch.MockOauth`)
+  to inject a test double without touching real HTTP paths.
+  """
+  @spec oauth_client :: module()
+  def oauth_client,
+    do:
+      Application.get_env(
+        :stream_closed_captioner_phoenix,
+        :twitch_oauth_client,
+        Twitch.Oauth
+      )
 
   @spec extension_live_channels :: list
   def extension_live_channels() do
@@ -80,7 +100,10 @@ defmodule Twitch do
   Get the live streams for a list of user ids
 
   Twitch API only allows 100 user ids per request, so we chunk the list
-  and make multiple requests.
+  and make multiple requests. The client access token is fetched once per
+  call and reused for each chunk. Results are cached for #{div(@cache_ttl, 60_000)}
+  minutes keyed on the sorted, normalised set of user IDs so different callers
+  with the same logical set do not produce duplicate network requests.
 
   # Examples
       iex(18)> Twitch.get_live_streams(["123", "456"])
@@ -118,25 +141,25 @@ defmodule Twitch do
   @spec get_live_streams(list(binary())) :: list(Twitch.Helix.Stream.t())
   def get_live_streams([]), do: []
 
-  # @decorate cacheable(
-  #             cache: Cache,
-  #             key: "twitch:live_streams",
-  #             ttl: 300_000
-  #           )
+  @decorate cacheable(
+              cache: Cache,
+              key: {:twitch_live_streams, Enum.sort(user_ids)},
+              opts: [ttl: @cache_ttl]
+            )
   def get_live_streams(user_ids) do
-    chunked_user_ids = Enum.chunk_every(user_ids, 80)
+    case oauth_client().get_client_access_token() do
+      {:ok, credentials} ->
+        user_ids
+        |> Enum.chunk_every(80)
+        |> Enum.flat_map(fn uids -> helix_api_client().get_streams(credentials, uids, nil) end)
+        |> Enum.sort_by(& &1.user_id, :desc)
+        |> Enum.dedup_by(fn stream -> stream.user_id end)
+        |> Enum.sort_by(& &1.viewer_count, :desc)
 
-    Enum.flat_map(chunked_user_ids, fn uids ->
-      case Oauth.get_client_access_token() do
-        {:ok, credentials} -> helix_api_client().get_streams(credentials, uids)
-        {:error, reason} ->
-          Logger.warning("Twitch: get_live_streams OAuth failed: #{inspect(reason)}")
-          []
-      end
-    end)
-    |> Enum.sort_by(& &1.user_id, :desc)
-    |> Enum.dedup_by(fn stream -> stream.user_id end)
-    |> Enum.sort_by(& &1.viewer_count, :desc)
+      {:error, reason} ->
+        Logger.warning("Twitch: get_live_streams OAuth failed: #{inspect(reason)}")
+        []
+    end
   end
 
   @spec get_extension_transactons() :: list

--- a/lib/stream_closed_captioner_phoenix/services/twitch/helix.ex
+++ b/lib/stream_closed_captioner_phoenix/services/twitch/helix.ex
@@ -10,6 +10,9 @@ defmodule Twitch.Helix do
 
   @behaviour Twitch.HelixProvider
 
+  # Connect and receive timeouts applied to every Twitch Helix API call.
+  @http_timeout [timeout: 5_000, recv_timeout: 10_000]
+
   @impl HelixProvider
   def get_streams(
         %{access_token: access_token} = credentials,
@@ -28,7 +31,7 @@ defmodule Twitch.Helix do
       end
 
     case encode_url_and_params("https://api.twitch.tv/helix/streams", params)
-         |> HTTPoison.get(headers) do
+         |> HTTPoison.get(headers, @http_timeout) do
       {:ok, %{status_code: status, body: raw_body}} when status in 200..299 ->
         case Jason.decode(raw_body) do
           {:ok, data} ->
@@ -63,7 +66,7 @@ defmodule Twitch.Helix do
     case encode_url_and_params("https://api.twitch.tv/helix/extensions/transactions", %{
            extension_id: client_id
          })
-         |> HTTPoison.get(headers) do
+         |> HTTPoison.get(headers, @http_timeout) do
       {:ok, %{status_code: status, body: raw_body}} when status in 200..299 ->
         case Jason.decode(raw_body) do
           {:ok, data} -> Enum.map(get_in(data, ["data"]) || [], &Transaction.new/1)
@@ -87,7 +90,7 @@ defmodule Twitch.Helix do
     headers = HttpHelpers.auth_request_headers(access_token)
 
     case encode_url_and_params("https://api.twitch.tv/helix/users/extensions")
-         |> HTTPoison.get(headers) do
+         |> HTTPoison.get(headers, @http_timeout) do
       {:ok, %{status_code: status, body: raw_body}} when status in 200..299 ->
         case Jason.decode(raw_body) do
           {:ok, data} -> Map.get(data, "data")
@@ -134,7 +137,7 @@ defmodule Twitch.Helix do
         %{broadcaster_id: broadcaster_id}
       )
 
-    case HTTPoison.post(url, body, headers) do
+    case HTTPoison.post(url, body, headers, @http_timeout) do
       {:ok, %{body: raw_body}} ->
         raw_body
 
@@ -159,7 +162,7 @@ defmodule Twitch.Helix do
              extension_id: Twitch.extension_id()
            }
          )
-         |> HTTPoison.get(headers) do
+         |> HTTPoison.get(headers, @http_timeout) do
       {:ok, %{status_code: status, body: raw_body}} when status in 200..299 ->
         case Jason.decode(raw_body) do
           {:ok, data} ->
@@ -206,7 +209,7 @@ defmodule Twitch.Helix do
 
     "https://api.twitch.tv/helix/extensions/configurations"
     |> encode_url_and_params()
-    |> HTTPoison.put(body, headers)
+    |> HTTPoison.put(body, headers, @http_timeout)
   end
 
   @impl HelixProvider
@@ -223,7 +226,7 @@ defmodule Twitch.Helix do
            extension_id: Twitch.extension_id(),
            segment: to_string(segment)
          })
-         |> HTTPoison.get(headers) do
+         |> HTTPoison.get(headers, @http_timeout) do
       {:ok, %{status_code: status, body: raw_body}} when status in 200..299 ->
         case Jason.decode(raw_body) do
           {:ok, decoded} ->
@@ -271,7 +274,7 @@ defmodule Twitch.Helix do
 
     url = encode_url_and_params("https://api.twitch.tv/helix/eventsub/subscriptions")
 
-    case HTTPoison.post(url, body, headers) do
+    case HTTPoison.post(url, body, headers, @http_timeout) do
       {:ok, %{status_code: status, body: raw_body}} when status in 200..299 ->
         case Jason.decode(raw_body) do
           {:ok, decoded} ->
@@ -315,7 +318,7 @@ defmodule Twitch.Helix do
       end
 
     case encode_url_and_params("https://api.twitch.tv/helix/eventsub/subscriptions", params)
-         |> HTTPoison.get(headers) do
+         |> HTTPoison.get(headers, @http_timeout) do
       {:ok, %{status_code: status, body: raw_body}} when status in 200..299 ->
         case Jason.decode(raw_body) do
           {:ok, data} ->
@@ -357,7 +360,7 @@ defmodule Twitch.Helix do
     headers = HttpHelpers.auth_request_headers(access_token)
 
     case encode_url_and_params("https://api.twitch.tv/helix/eventsub/subscriptions", %{id: id})
-         |> HTTPoison.delete(headers) do
+         |> HTTPoison.delete(headers, @http_timeout) do
       {:ok, %{status_code: status_code}} ->
         status_code
 

--- a/lib/stream_closed_captioner_phoenix/services/twitch/oauth.ex
+++ b/lib/stream_closed_captioner_phoenix/services/twitch/oauth.ex
@@ -8,6 +8,12 @@ defmodule Twitch.Oauth do
   alias Twitch.Parser
   alias NewRelic.Instrumented.HTTPoison
 
+  @behaviour Twitch.OauthProvider
+
+  # Connect and receive timeouts applied to every Twitch identity endpoint call.
+  @http_timeout [timeout: 5_000, recv_timeout: 10_000]
+
+  @impl Twitch.OauthProvider
   def get_client_access_token() do
     credentials = get_credentials()
 
@@ -25,7 +31,7 @@ defmodule Twitch.Oauth do
 
     url = encode_url_and_params("https://id.twitch.tv/oauth2/token", params)
 
-    case HTTPoison.post(url, "", headers) do
+    case HTTPoison.post(url, "", headers, @http_timeout) do
       {:ok, %{status_code: status, body: raw_body}} when status in 200..299 ->
         case Jason.decode(raw_body) do
           {:ok, data} ->
@@ -70,7 +76,7 @@ defmodule Twitch.Oauth do
     ]
 
     encode_url_and_params("https://id.twitch.tv/oauth2/validate")
-    |> HTTPoison.get(headers)
+    |> HTTPoison.get(headers, @http_timeout)
     |> Parser.parse()
   end
 

--- a/lib/stream_closed_captioner_phoenix/services/twitch/oauth_provider.ex
+++ b/lib/stream_closed_captioner_phoenix/services/twitch/oauth_provider.ex
@@ -1,0 +1,10 @@
+defmodule Twitch.OauthProvider do
+  @moduledoc """
+  Behaviour for the Twitch OAuth client. Provides a seam for injecting a
+  test double via application config without touching production code paths.
+  """
+
+  alias Twitch.Helix.Credentials
+
+  @callback get_client_access_token() :: {:ok, Credentials.t()} | {:error, term()}
+end

--- a/lib/stream_closed_captioner_phoenix_web/controllers/announcements_controller.ex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/announcements_controller.ex
@@ -1,13 +1,10 @@
 defmodule StreamClosedCaptionerPhoenixWeb.AnnouncementsController do
   use StreamClosedCaptionerPhoenixWeb, :controller
 
-  def index(conn, _params) do
-    pages =
-      case Notion.Database.query_database("8f9f6076e708455fbb263b3ba9ca48db") do
-        {:ok, response} -> get_in(response, ["results"])
-        _ -> []
-      end
+  alias StreamClosedCaptionerPhoenix.Announcements
 
+  def index(conn, _params) do
+    pages = Announcements.list_announcement_pages()
     render(conn, "index.html", pages: pages)
   end
 end

--- a/test/stream_closed_captioner_phoenix/announcements_test.exs
+++ b/test/stream_closed_captioner_phoenix/announcements_test.exs
@@ -1,0 +1,107 @@
+defmodule StreamClosedCaptionerPhoenix.AnnouncementsTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias StreamClosedCaptionerPhoenix.Announcements
+  alias StreamClosedCaptionerPhoenix.Cache
+
+  @cache_key :notion_announcements_pages
+  @notion_db_id "8f9f6076e708455fbb263b3ba9ca48db"
+
+  setup :verify_on_exit!
+
+  setup do
+    Cache.delete(@cache_key)
+    :ok
+  end
+
+  describe "list_announcement_pages/0" do
+    test "calls Notion and returns the results list on success" do
+      pages = [%{"id" => "page-1"}, %{"id" => "page-2"}]
+
+      Notion.MockDatabase
+      |> expect(:query_database, fn @notion_db_id, %{} ->
+        {:ok, %{"results" => pages}}
+      end)
+
+      assert Announcements.list_announcement_pages() == pages
+    end
+
+    test "returns empty list when Notion returns an error" do
+      Notion.MockDatabase
+      |> expect(:query_database, fn @notion_db_id, %{} ->
+        {:error, :timeout}
+      end)
+
+      assert Announcements.list_announcement_pages() == []
+    end
+
+    test "returns empty list when Notion response has no 'results' key" do
+      Notion.MockDatabase
+      |> expect(:query_database, fn @notion_db_id, %{} ->
+        {:ok, %{}}
+      end)
+
+      assert Announcements.list_announcement_pages() == []
+    end
+
+    test "caches results so Notion is only called once across repeated requests" do
+      pages = [%{"id" => "cached-page"}]
+
+      # expect exactly 1 call — second invocation must come from cache
+      Notion.MockDatabase
+      |> expect(:query_database, 1, fn @notion_db_id, %{} ->
+        {:ok, %{"results" => pages}}
+      end)
+
+      assert Announcements.list_announcement_pages() == pages
+      assert Announcements.list_announcement_pages() == pages
+    end
+
+    test "calls Notion again when the cache has been cleared" do
+      pages_first = [%{"id" => "first"}]
+      pages_second = [%{"id" => "second"}]
+
+      Notion.MockDatabase
+      |> expect(:query_database, fn @notion_db_id, %{} ->
+        {:ok, %{"results" => pages_first}}
+      end)
+
+      assert Announcements.list_announcement_pages() == pages_first
+
+      Cache.delete(@cache_key)
+
+      Notion.MockDatabase
+      |> expect(:query_database, fn @notion_db_id, %{} ->
+        {:ok, %{"results" => pages_second}}
+      end)
+
+      assert Announcements.list_announcement_pages() == pages_second
+    end
+
+    test "does not cache empty results from a Notion error (allows retry on next request)" do
+      Notion.MockDatabase
+      |> expect(:query_database, 2, fn @notion_db_id, %{} ->
+        {:error, :unavailable}
+      end)
+
+      assert Announcements.list_announcement_pages() == []
+      assert Announcements.list_announcement_pages() == []
+    end
+
+    test "does not cache an empty results list from a successful Notion response (allows retry on next request)" do
+      # Notion responds OK but with zero pages — e.g. the DB is temporarily empty.
+      # Two consecutive calls must both reach Notion; the empty list must not be
+      # written to cache, because on the next publish the page would stay blank
+      # until the TTL expires.
+      Notion.MockDatabase
+      |> expect(:query_database, 2, fn @notion_db_id, %{} ->
+        {:ok, %{"results" => []}}
+      end)
+
+      assert Announcements.list_announcement_pages() == []
+      assert Announcements.list_announcement_pages() == []
+    end
+  end
+end

--- a/test/stream_closed_captioner_phoenix/jobs/send_chat_reminder_test.exs
+++ b/test/stream_closed_captioner_phoenix/jobs/send_chat_reminder_test.exs
@@ -10,37 +10,75 @@ defmodule StreamClosedCaptionerPhoenix.Jobs.SendChatReminderTest do
     UserTracker.untrack(self(), "active_channels", "123")
   end
 
-  test "it sends a chat message to the broadcaster if the channel is not active" do
-    Twitch.MockHelix
-    |> expect(:send_extension_chat_message, fn _creds, "123", message ->
-      assert message ==
-               "Hey @talk2megooseman, here is your friendly reminder to turn on Stream Closed Captioner."
+  # ---------------------------------------------------------------------------
+  # Worker configuration assertions
+  # These verify the module-level Oban options match the intended isolation
+  # design, giving a clear failure message if someone accidentally reverts them.
+  # ---------------------------------------------------------------------------
 
-      {:ok, %{}}
-    end)
+  describe "worker configuration" do
+    test "routes jobs through the dedicated chat_reminders queue" do
+      assert SendChatReminder.__opts__()[:queue] == :chat_reminders
+    end
 
-    # Enqueue a job
-    assert :ok =
-             Oban.Testing.perform_job(
-               SendChatReminder,
-               %{broadcaster_user_id: "123", broadcaster_user_login: "talk2megooseman"},
-               []
-             )
+    test "limits retry attempts to 3" do
+      assert SendChatReminder.__opts__()[:max_attempts] == 3
+    end
 
-    verify!()
+    test "enforces uniqueness by args and queue to prevent duplicate reminders" do
+      unique_opts = SendChatReminder.__opts__()[:unique]
+      assert is_list(unique_opts), "expected unique opts to be present"
+      assert :args in unique_opts[:fields], "expected :args to be a uniqueness field"
+      assert :queue in unique_opts[:fields], "expected :queue to be a uniqueness field"
+    end
   end
 
-  test "it does not send a chat message to the broadcaster if the channel is active" do
-    UserTracker.track(self(), "active_channels", "123", %{
-      last_publish: System.system_time(:second)
-    })
+  # ---------------------------------------------------------------------------
+  # perform/1 behavioural assertions
+  # ---------------------------------------------------------------------------
 
-    # Enqueue a job
-    assert :ok =
-             Oban.Testing.perform_job(
-               SendChatReminder,
-               %{broadcaster_user_id: "123", broadcaster_user_login: "talk2megooseman"},
-               []
-             )
+  describe "perform/1" do
+    test "sends a chat message to the broadcaster when the channel is not active" do
+      Twitch.MockHelix
+      |> expect(:send_extension_chat_message, fn _creds, "123", message ->
+        assert message ==
+                 "Hey @talk2megooseman, here is your friendly reminder to turn on Stream Closed Captioner."
+
+        {:ok, %{}}
+      end)
+
+      assert :ok =
+               Oban.Testing.perform_job(
+                 SendChatReminder,
+                 %{broadcaster_user_id: "123", broadcaster_user_login: "talk2megooseman"},
+                 []
+               )
+
+      verify!()
+    end
+
+    test "does not send a chat message when the channel is already active" do
+      UserTracker.track(self(), "active_channels", "123", %{
+        last_publish: System.system_time(:second)
+      })
+
+      assert :ok =
+               Oban.Testing.perform_job(
+                 SendChatReminder,
+                 %{broadcaster_user_id: "123", broadcaster_user_login: "talk2megooseman"},
+                 []
+               )
+    end
+
+    test "cancels the job without sending when there are prior errors" do
+      # On a prior-error the worker returns {:cancel, reason} so Oban discards the job
+      # rather than letting it exhaust all attempts with a known-bad state.
+      assert {:cancel, _reason} =
+               Oban.Testing.perform_job(
+                 SendChatReminder,
+                 %{broadcaster_user_id: "123", broadcaster_user_login: "talk2megooseman"},
+                 errors: [%{"attempt" => 1, "error" => "prior failure", "at" => DateTime.utc_now()}]
+               )
+    end
   end
 end

--- a/test/stream_closed_captioner_phoenix/services/twitch_test.exs
+++ b/test/stream_closed_captioner_phoenix/services/twitch_test.exs
@@ -1,14 +1,23 @@
 defmodule StreamClosedCaptionerPhoenix.Services.TwitchTest do
-  use ExUnit.Case, async: true
+  # async: false because get_live_streams tests exercise the shared Cache singleton.
+  use ExUnit.Case, async: false
 
   import Mox
 
   setup :verify_on_exit!
 
+  alias StreamClosedCaptionerPhoenix.Cache
   alias Twitch.Extension.CaptionsPayload
+  alias Twitch.Helix.{Credentials, Stream}
 
   @channel_id "123456"
   @payload %CaptionsPayload{interim: "hello", final: "hello world", delay: 0.5}
+
+  @credentials %Credentials{
+    client_id: "TWITCHCLIENTID",
+    client_secret: "TWITCHCLIENTSECRET",
+    access_token: "test_access_token"
+  }
 
   describe "send_pubsub_message/2" do
     test "returns error when channel_id is nil" do
@@ -67,6 +76,158 @@ defmodule StreamClosedCaptionerPhoenix.Services.TwitchTest do
       end)
 
       assert {:error, :timeout} = Twitch.send_pubsub_message(@payload, @channel_id)
+    end
+  end
+
+  describe "get_live_streams/1" do
+    # Clear cache before each test so results from one test cannot bleed into the next.
+    setup do
+      Cache.delete_all()
+      :ok
+    end
+
+    test "returns [] immediately for empty input without touching OAuth or Helix" do
+      # No expectations set — Mox will fail verify_on_exit! if either mock is called.
+      assert [] == Twitch.get_live_streams([])
+    end
+
+    test "returns [] and logs a warning when OAuth fails" do
+      expect(Twitch.MockOauth, :get_client_access_token, fn ->
+        {:error, {:http, :econnrefused}}
+      end)
+
+      assert [] == Twitch.get_live_streams(["123"])
+    end
+
+    test "fetches the client token exactly once for a single chunk and passes it to Helix" do
+      user_ids = ["100", "200"]
+
+      # Mox enforces the count: exactly 1 OAuth call, exactly 1 Helix call.
+      expect(Twitch.MockOauth, :get_client_access_token, 1, fn ->
+        {:ok, @credentials}
+      end)
+
+      expect(Twitch.MockHelix, :get_streams, 1, fn creds, ^user_ids, nil ->
+        assert creds == @credentials
+        [
+          %Stream{user_id: "200", viewer_count: 200},
+          %Stream{user_id: "100", viewer_count: 100}
+        ]
+      end)
+
+      result = Twitch.get_live_streams(user_ids)
+
+      assert [%Stream{user_id: "200"}, %Stream{user_id: "100"}] = result
+    end
+
+    test "fetches the client token exactly once even when user_ids span multiple Helix chunks" do
+      # 82 IDs → chunk_every(80) produces 2 chunks; token must be fetched only once.
+      user_ids = Enum.map(1..82, &Integer.to_string/1)
+      [chunk_1, chunk_2] = Enum.chunk_every(user_ids, 80)
+
+      expect(Twitch.MockOauth, :get_client_access_token, 1, fn ->
+        {:ok, @credentials}
+      end)
+
+      expect(Twitch.MockHelix, :get_streams, fn _creds, ^chunk_1, nil ->
+        [%Stream{user_id: "1", viewer_count: 50}]
+      end)
+
+      expect(Twitch.MockHelix, :get_streams, fn _creds, ^chunk_2, nil ->
+        [%Stream{user_id: "81", viewer_count: 300}]
+      end)
+
+      result = Twitch.get_live_streams(user_ids)
+
+      assert length(result) == 2
+      # Final sort is by viewer_count descending.
+      assert hd(result).user_id == "81"
+      assert hd(result).viewer_count == 300
+    end
+
+    test "returns streams sorted by viewer_count descending" do
+      expect(Twitch.MockOauth, :get_client_access_token, fn -> {:ok, @credentials} end)
+
+      expect(Twitch.MockHelix, :get_streams, fn _creds, _uids, nil ->
+        [
+          %Stream{user_id: "a", viewer_count: 10},
+          %Stream{user_id: "b", viewer_count: 500},
+          %Stream{user_id: "c", viewer_count: 100}
+        ]
+      end)
+
+      [first | rest] = Twitch.get_live_streams(["a", "b", "c"])
+
+      assert first.viewer_count == 500
+      assert List.last(rest).viewer_count == 10
+    end
+
+    test "deduplicates streams by user_id, keeping first occurrence after user_id desc sort" do
+      expect(Twitch.MockOauth, :get_client_access_token, fn -> {:ok, @credentials} end)
+
+      expect(Twitch.MockHelix, :get_streams, fn _creds, _uids, nil ->
+        [
+          %Stream{user_id: "999", viewer_count: 100},
+          %Stream{user_id: "999", viewer_count: 50}
+        ]
+      end)
+
+      result = Twitch.get_live_streams(["999"])
+
+      assert length(result) == 1
+      assert hd(result).user_id == "999"
+    end
+
+    test "caches the result: Helix and OAuth are called only once for repeated identical inputs" do
+      user_ids = ["aaa", "bbb"]
+
+      # Exactly 1 OAuth and 1 Helix call across 2 invocations — the second hits cache.
+      expect(Twitch.MockOauth, :get_client_access_token, 1, fn -> {:ok, @credentials} end)
+
+      expect(Twitch.MockHelix, :get_streams, 1, fn _creds, ^user_ids, nil ->
+        [
+          %Stream{user_id: "aaa", viewer_count: 10},
+          %Stream{user_id: "bbb", viewer_count: 20}
+        ]
+      end)
+
+      first_result = Twitch.get_live_streams(user_ids)
+      second_result = Twitch.get_live_streams(user_ids)
+
+      assert first_result == second_result
+    end
+
+    test "different user_id sets use independent cache slots" do
+      # Two distinct inputs → two OAuth calls, two Helix calls.
+      expect(Twitch.MockOauth, :get_client_access_token, 2, fn -> {:ok, @credentials} end)
+
+      expect(Twitch.MockHelix, :get_streams, fn _creds, ["set_a"], nil ->
+        [%Stream{user_id: "set_a", viewer_count: 1}]
+      end)
+
+      expect(Twitch.MockHelix, :get_streams, fn _creds, ["set_b"], nil ->
+        [%Stream{user_id: "set_b", viewer_count: 2}]
+      end)
+
+      result_a = Twitch.get_live_streams(["set_a"])
+      result_b = Twitch.get_live_streams(["set_b"])
+
+      assert [%Stream{user_id: "set_a"}] = result_a
+      assert [%Stream{user_id: "set_b"}] = result_b
+    end
+
+    test "cache key is order-independent: reversed input hits the same cache slot" do
+      # Helix and OAuth called exactly once even though inputs are in different order.
+      expect(Twitch.MockOauth, :get_client_access_token, 1, fn -> {:ok, @credentials} end)
+
+      expect(Twitch.MockHelix, :get_streams, 1, fn _creds, _uids, nil ->
+        [%Stream{user_id: "x", viewer_count: 10}]
+      end)
+
+      first = Twitch.get_live_streams(["x", "y"])
+      second = Twitch.get_live_streams(["y", "x"])
+
+      assert first == second
     end
   end
 end

--- a/test/stream_closed_captioner_phoenix_web/controllers/announcements_controller_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/controllers/announcements_controller_test.exs
@@ -1,0 +1,80 @@
+defmodule StreamClosedCaptionerPhoenixWeb.AnnouncementsControllerTest do
+  use StreamClosedCaptionerPhoenixWeb.ConnCase, async: false
+
+  import Mox
+
+  alias StreamClosedCaptionerPhoenix.Cache
+
+  @cache_key :notion_announcements_pages
+  @notion_db_id "8f9f6076e708455fbb263b3ba9ca48db"
+
+  setup :verify_on_exit!
+
+  setup do
+    Cache.delete(@cache_key)
+    :ok
+  end
+
+  describe "GET /announcements" do
+    test "renders the announcements page with pages returned from Notion", %{conn: conn} do
+      pages = [
+        %{
+          "id" => "abc-123",
+          "properties" => %{
+            "Name" => %{"title" => [%{"plain_text" => "My Announcement"}]},
+            "Published" => %{"date" => %{"start" => "2024-01-15"}},
+            "tldr" => %{"rich_text" => [%{"plain_text" => "A short summary"}]}
+          }
+        }
+      ]
+
+      Notion.MockDatabase
+      |> expect(:query_database, fn @notion_db_id, %{} ->
+        {:ok, %{"results" => pages}}
+      end)
+
+      conn = get(conn, ~p"/announcements")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "My Announcement"
+    end
+
+    test "renders the announcements page with an empty list when Notion fails", %{conn: conn} do
+      Notion.MockDatabase
+      |> expect(:query_database, fn @notion_db_id, %{} ->
+        {:error, :timeout}
+      end)
+
+      conn = get(conn, ~p"/announcements")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "Annoucements and News"
+    end
+
+    test "does not hit Notion on a second request within the cache TTL", %{conn: conn} do
+      pages = [
+        %{
+          "id" => "xyz-456",
+          "properties" => %{
+            "Name" => %{"title" => [%{"plain_text" => "Cached Post"}]},
+            "Published" => %{"date" => %{"start" => "2024-02-01"}},
+            "tldr" => %{"rich_text" => [%{"plain_text" => "Cached summary"}]}
+          }
+        }
+      ]
+
+      # Notion is called exactly once; the second request is served from cache
+      Notion.MockDatabase
+      |> expect(:query_database, 1, fn @notion_db_id, %{} ->
+        {:ok, %{"results" => pages}}
+      end)
+
+      conn1 = get(conn, ~p"/announcements")
+      assert conn1.status == 200
+
+      conn2 = get(conn, ~p"/announcements")
+      assert conn2.status == 200
+      assert conn2.resp_body =~ "Cached Post"
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,5 +6,7 @@ Ecto.Adapters.SQL.Sandbox.mode(StreamClosedCaptionerPhoenix.Repo, :manual)
 # Mocks services out using their provider
 Mox.defmock(Azure.MockCognitive, for: Azure.CognitiveProvider)
 Mox.defmock(Gemini.MockCognitive, for: Gemini.CognitiveProvider)
+Mox.defmock(Notion.MockDatabase, for: Notion.DatabaseProvider)
 Mox.defmock(Twitch.MockExtension, for: Twitch.ExtensionProvider)
 Mox.defmock(Twitch.MockHelix, for: Twitch.HelixProvider)
+Mox.defmock(Twitch.MockOauth, for: Twitch.OauthProvider)


### PR DESCRIPTION
This change removes a few of the highest-latency paths in the app so the showcase and reminder flows spend less time waiting on upstream APIs.

## What changed
- Restores Twitch live-stream caching with a cache key based on the normalized `user_ids` input.
- Fetches the Twitch OAuth token once per live-stream lookup and reuses it for each Helix chunk.
- Adds explicit HTTP timeouts to Twitch Helix and OAuth requests so slow upstream responses fail fast.
- Moves announcements behind a short-lived cached context so the controller does not hit Notion on every request.
- Isolates `SendChatReminder` in a dedicated low-concurrency Oban queue with bounded retries.

## Notes
- The live-stream cache key is input-aware so different channel sets do not collide.
- The announcements cache intentionally avoids caching empty or failed Notion responses so the page can recover quickly after a transient issue.
- The reminder job now returns the Oban cancel tuple form expected by the current worker API.

## Verification
- `mix test`