### PR TITLE
Add live speech confidence meter to dashboard caption preview

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1079,8 +1079,8 @@ html:has(.scc-home) { scroll-behavior: smooth; }
 .scc-home .conf-chip__pct { font-weight: 700; min-width: 3ch; text-align: right; color: var(--ok); }
 .scc-home .conf-chip[data-level="fair"] .conf-chip__fill { background: var(--warn); }
 .scc-home .conf-chip[data-level="fair"] .conf-chip__pct { color: var(--warn); }
-.scc-home .conf-chip[data-level="low"] .conf-chip__fill { background: oklch(0.7 0.19 25); }
-.scc-home .conf-chip[data-level="low"] .conf-chip__pct { color: oklch(0.7 0.19 25); }
+.scc-home .conf-chip[data-level="low"] .conf-chip__fill { background: var(--live); }
+.scc-home .conf-chip[data-level="low"] .conf-chip__pct { color: var(--live); }
 .scc-home .skel { height: 15px; border-radius: 7px; background: linear-gradient(90deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.13), rgba(255, 255, 255, 0.07)); background-size: 200% 100%; animation: shimmer 1.8s linear infinite; }
 @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
 @media (prefers-reduced-motion: reduce) { .scc-home .skel { animation: none; } }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1083,7 +1083,7 @@ html:has(.scc-home) { scroll-behavior: smooth; }
 .scc-home .conf-chip[data-level="low"] .conf-chip__pct { color: var(--live); }
 .scc-home .skel { height: 15px; border-radius: 7px; background: linear-gradient(90deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.13), rgba(255, 255, 255, 0.07)); background-size: 200% 100%; animation: shimmer 1.8s linear infinite; }
 @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
-@media (prefers-reduced-motion: reduce) { .scc-home .skel { animation: none; } }
+@media (prefers-reduced-motion: reduce) { .scc-home .skel { animation: none; } .scc-home .conf-chip__fill { transition: none; } }
 .scc-home .stage-empty { display: flex; flex-direction: column; gap: 13px; }
 .scc-home .stage-empty.hidden { display: none; }
 .scc-home .stage-empty__note { margin-top: 6px; font-family: var(--mono); font-size: 11px; color: rgba(255, 255, 255, 0.66); letter-spacing: 0.04em; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1072,6 +1072,15 @@ html:has(.scc-home) { scroll-behavior: smooth; }
 }
 .scc-home .capctl__stage .stagetag { position: absolute; top: 14px; left: 18px; font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: rgba(255, 255, 255, 0.56); display: inline-flex; align-items: center; gap: 8px; }
 .scc-home .capctl__stage .stagetag .rec { width: 8px; height: 8px; border-radius: 50%; background: rgba(255, 255, 255, 0.28); }
+.scc-home .capctl__stage .conf-chip { position: absolute; top: 11px; right: 14px; display: inline-flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: rgba(255, 255, 255, 0.62); }
+.scc-home .capctl__stage .conf-chip.hidden { display: none; }
+.scc-home .conf-chip__bar { width: 64px; height: 5px; border-radius: 999px; background: rgba(255, 255, 255, 0.14); overflow: hidden; }
+.scc-home .conf-chip__fill { display: block; height: 100%; width: 0; border-radius: 999px; background: var(--ok); transition: width 0.25s ease; }
+.scc-home .conf-chip__pct { font-weight: 700; min-width: 3ch; text-align: right; color: var(--ok); }
+.scc-home .conf-chip[data-level="fair"] .conf-chip__fill { background: var(--warn); }
+.scc-home .conf-chip[data-level="fair"] .conf-chip__pct { color: var(--warn); }
+.scc-home .conf-chip[data-level="low"] .conf-chip__fill { background: oklch(0.7 0.19 25); }
+.scc-home .conf-chip[data-level="low"] .conf-chip__pct { color: oklch(0.7 0.19 25); }
 .scc-home .skel { height: 15px; border-radius: 7px; background: linear-gradient(90deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.13), rgba(255, 255, 255, 0.07)); background-size: 200% 100%; animation: shimmer 1.8s linear infinite; }
 @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
 @media (prefers-reduced-motion: reduce) { .scc-home .skel { animation: none; } }

--- a/assets/js/SpeechRecognitionHandler.js
+++ b/assets/js/SpeechRecognitionHandler.js
@@ -11,7 +11,7 @@ const debug = debugLogger("cc:speech-handler")
  * {{
  *    interim: string,
  *    final: string,
- *    session: number,
+ *    session: string,
  *    confidence: ?number,
  * }} SpeechInterval
  */

--- a/assets/js/SpeechRecognitionHandler.js
+++ b/assets/js/SpeechRecognitionHandler.js
@@ -12,6 +12,7 @@ const debug = debugLogger("cc:speech-handler")
  *    interim: string,
  *    final: string,
  *    session: number,
+ *    confidence: ?number,
  * }} SpeechInterval
  */
 

--- a/assets/js/controllers/captions_controller.js
+++ b/assets/js/controllers/captions_controller.js
@@ -222,7 +222,7 @@ export default class extends Controller {
         .receive("ok", (response) => {
           const seq = getZoomSequence(this.zoomData.url) + 1
           setZoomSequence(this.zoomData.url, seq)
-          this.displayConfidence(confidence)
+          this.displayCaptions(response, confidence)
         })
     } else {
       const publishData = {

--- a/assets/js/controllers/captions_controller.js
+++ b/assets/js/controllers/captions_controller.js
@@ -26,6 +26,9 @@ export default class extends Controller {
     "finalOutput",
     "interimOutput",
     "translationOutput",
+    "confidence",
+    "confidenceFill",
+    "confidencePct",
     "start",
     "warning"
   ]
@@ -201,9 +204,13 @@ export default class extends Controller {
 
   receiveFinalMessage = (data) => {
     debug('final', data)
+    // Confidence is dashboard-only; keep it off the channel payload
+    const { confidence, ...speechData } = data
+    this.displayConfidence(confidence)
+
     if (this.zoomData.enabled) {
       const publishData = {
-        ...data,
+        ...speechData,
         zoom: {
           ...this.zoomData,
           seq: getZoomSequence(this.zoomData.url)
@@ -218,7 +225,7 @@ export default class extends Controller {
         })
     } else {
       const publishData = {
-        ...data,
+        ...speechData,
         sentOn: (new Date()).toISOString(),
         twitch: this.twitchData,
       }
@@ -227,6 +234,21 @@ export default class extends Controller {
         .push("publishFinal", publishData, 5000)
         .receive("ok", (response) => this.displayCaptions(response))
     }
+  }
+
+  // Per-utterance meter beside the preview tag. Only final results carry a
+  // usable score (interim confidence is 0 in Chrome), and some engines never
+  // report one — the chip stays hidden until the first real value arrives.
+  displayConfidence = (confidence) => {
+    if (!this.hasConfidenceTarget || confidence == null) return
+
+    const pct = Math.round(confidence * 100)
+    const level = confidence >= 0.8 ? "high" : confidence >= 0.5 ? "fair" : "low"
+
+    this.confidenceTarget.classList.remove("hidden")
+    this.confidenceTarget.dataset.level = level
+    this.confidenceFillTarget.style.width = `${pct}%`
+    this.confidencePctTarget.textContent = `${pct}%`
   }
 
   displayCaptions = (captions) => {

--- a/assets/js/controllers/captions_controller.js
+++ b/assets/js/controllers/captions_controller.js
@@ -204,9 +204,9 @@ export default class extends Controller {
 
   receiveFinalMessage = (data) => {
     debug('final', data)
-    // Confidence is dashboard-only; keep it off the channel payload
+    // Confidence is dashboard-only; keep it off the channel payload and apply
+    // it on the "ok" reply so the chip lands together with the rendered caption.
     const { confidence, ...speechData } = data
-    this.displayConfidence(confidence)
 
     if (this.zoomData.enabled) {
       const publishData = {
@@ -222,6 +222,7 @@ export default class extends Controller {
         .receive("ok", (response) => {
           const seq = getZoomSequence(this.zoomData.url) + 1
           setZoomSequence(this.zoomData.url, seq)
+          this.displayConfidence(confidence)
         })
     } else {
       const publishData = {
@@ -232,7 +233,7 @@ export default class extends Controller {
 
       this.captionsChannel
         .push("publishFinal", publishData, 5000)
-        .receive("ok", (response) => this.displayCaptions(response))
+        .receive("ok", (response) => this.displayCaptions(response, confidence))
     }
   }
 
@@ -251,7 +252,9 @@ export default class extends Controller {
     this.confidencePctTarget.textContent = `${pct}%`
   }
 
-  displayCaptions = (captions) => {
+  // confidence is only passed for final results; interim calls leave it null
+  // so the chip keeps its last value rather than flickering between captions.
+  displayCaptions = (captions, confidence = null) => {
     this.dispatch("payload", { detail: { ...captions } })
 
     this.outputOutlineTarget.classList.add("hidden")
@@ -259,6 +262,8 @@ export default class extends Controller {
 
     this.interimOutputTarget.textContent = captions.interim
     this.finalOutputTarget.textContent = captions.final
+
+    this.displayConfidence(confidence)
 
     this.displayTranslations(captions)
   }

--- a/assets/js/service/SpeechRecognitionService.js
+++ b/assets/js/service/SpeechRecognitionService.js
@@ -25,6 +25,20 @@ const parseSpeechResults = pipe(
   join('')
 );
 
+/**
+ * Average the engine-reported confidence (0-1) across the recognition
+ * results. Returns null when nothing usable was reported — some engines
+ * send 0 for every result, and interim results carry no confidence.
+ *
+ * @param {SpeechRecognitionResultList} speechArray
+ * @returns {?number}
+ */
+const parseSpeechConfidence = (speechArray) => {
+  const scores = map(path([0, 'confidence']), speechArray).filter((c) => c > 0);
+  if (isEmpty(scores)) return null;
+  return scores.reduce((sum, c) => sum + c, 0) / scores.length;
+};
+
 export default class SpeechRecognitionService {
   constructor() {
     this.onSpeechInterimCallback = null;
@@ -61,7 +75,7 @@ export default class SpeechRecognitionService {
     if (isFinalSpeechResult(event.results)) {
       let finalText = parseSpeechResults(event.results);
       this.throttledPublishInterim.cancel();
-      this.publishFinalText(finalText)
+      this.publishFinalText(finalText, parseSpeechConfidence(event.results))
     } else {
       let interimText = parseSpeechResults(event.results);
       this.throttledPublishInterim(interimText)
@@ -128,13 +142,14 @@ export default class SpeechRecognitionService {
     }
   }
 
-  publishFinalText(text) {
+  publishFinalText(text, confidence = null) {
     if (this.onSpeechFinalCallback) {
-      debug("Publish Final Text", { text })
+      debug("Publish Final Text", { text, confidence })
       this.onSpeechFinalCallback({
         session: this.sessionId,
         interim: '',
-        final: text
+        final: text,
+        confidence
       })
     }
   }

--- a/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/index.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/index.html.heex
@@ -140,6 +140,17 @@
             >
               <div class="capctl__stage">
                 <span class="stagetag"><span class="rec"></span>Preview</span>
+                <span
+                  class="conf-chip hidden"
+                  data-captions-target="confidence"
+                  title="Speech recognition confidence of the last caption"
+                >
+                  Confidence
+                  <span class="conf-chip__bar">
+                    <span class="conf-chip__fill" data-captions-target="confidenceFill"></span>
+                  </span>
+                  <span class="conf-chip__pct" data-captions-target="confidencePct"></span>
+                </span>
                 <div class="stage-empty" data-captions-target="outputOutline">
                   <div class="skel" style="width: 82%"></div>
                   <div class="skel" style="width: 94%"></div>

--- a/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/index.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/dashboard/index.html.heex
@@ -144,7 +144,12 @@
                   class="conf-chip hidden"
                   data-captions-target="confidence"
                   title="Speech recognition confidence of the last caption"
+                  aria-describedby="conf-chip-desc"
                 >
+                  <span class="sr-only" id="conf-chip-desc">
+                    How certain the speech recognition engine was about the last caption,
+                    from 0 to 100 percent.
+                  </span>
                   Confidence
                   <span class="conf-chip__bar">
                     <span class="conf-chip__fill" data-captions-target="confidenceFill"></span>


### PR DESCRIPTION
Surface the Web Speech API's per-result confidence score, previously
discarded, as a small meter chip in the corner of the caption preview
stage. The value is extracted on final recognition results (interim
results carry no usable confidence), averaged across the result list,
and flows through the existing delay queue so it lines up with the
caption it belongs to.

The chip stays hidden until the first real score arrives, since some
engines report 0 for every result, and is color-coded: green >= 80%,
amber 50-79%, red below. Confidence is dashboard-only and stripped
from the channel payload before publishing.

https://claude.ai/code/session_014hkSntA44qNVCqYvqmDj1v