### PR TITLE
Add channel connection validation to GraphQL subscriptions

### DIFF
--- a/lib/stream_closed_captioner_phoenix_web/channels/user_tracker.ex
+++ b/lib/stream_closed_captioner_phoenix_web/channels/user_tracker.ex
@@ -66,6 +66,14 @@ defmodule StreamClosedCaptionerPhoenixWeb.UserTracker do
     |> channel_recently_published?()
   end
 
+  @doc """
+  Returns true if any UserTracker entry exists for the channel, regardless of
+  last_publish age — i.e. the streamer's dashboard is open.
+
+  Distinct from `channel_active?/1`, which additionally requires a publish
+  within the last #{@active_time_out}s. Use `channel_connected?` to gate
+  subscription setup; use `channel_active?` for recency/showcase checks.
+  """
   def channel_connected?(channel_id) do
     get_by_key("active_channels", channel_id)
     |> Enum.any?()

--- a/lib/stream_closed_captioner_phoenix_web/channels/user_tracker.ex
+++ b/lib/stream_closed_captioner_phoenix_web/channels/user_tracker.ex
@@ -66,6 +66,11 @@ defmodule StreamClosedCaptionerPhoenixWeb.UserTracker do
     |> channel_recently_published?()
   end
 
+  def channel_connected?(channel_id) do
+    get_by_key("active_channels", channel_id)
+    |> Enum.any?()
+  end
+
   defp reduced_user_list({uid, metadata}, acc) when is_binary(uid) do
     elapsed_time = current_timestamp() - get_last_publish(metadata)
 

--- a/lib/stream_closed_captioner_phoenix_web/schema.ex
+++ b/lib/stream_closed_captioner_phoenix_web/schema.ex
@@ -111,11 +111,21 @@ defmodule StreamClosedCaptionerPhoenixWeb.Schema do
       # If needed, you can also provide a list of topics:
       #   {:ok, topic: ["absinthe-graphql/absinthe", "elixir-lang/elixir"]}
       # Absinthe.Subscription.publish(StreamClosedCaptionerPhoenixWeb.Endpoint, %{ interim: "hello", final: "final" }, new_twitch_caption: "1")
-      config(fn args, _ ->
+      # Gate is one-shot: evaluated once at subscribe time. If the streamer's
+      # CaptionsChannel hasn't joined yet, the client receives an error and must
+      # retry. The Twitch extension handles this via WebSocket reconnect logic.
+      #
+      # Uses channel_connected? (any tracker entry) not channel_active? (recent
+      # publish): a paused streamer's dashboard is still open, so subscriptions
+      # should be accepted and receive events when captioning resumes.
+      #
+      # _context unused — extension subscriptions are open to all viewers;
+      # auth is enforced at transport level by UserSocket.connect/3.
+      config(fn args, _context ->
         if StreamClosedCaptionerPhoenixWeb.UserTracker.channel_connected?(args.channel_id) do
           {:ok, topic: args.channel_id}
         else
-          {:error, "channel is not active"}
+          {:error, "channel is not connected"}
         end
       end)
     end

--- a/lib/stream_closed_captioner_phoenix_web/schema.ex
+++ b/lib/stream_closed_captioner_phoenix_web/schema.ex
@@ -112,7 +112,11 @@ defmodule StreamClosedCaptionerPhoenixWeb.Schema do
       #   {:ok, topic: ["absinthe-graphql/absinthe", "elixir-lang/elixir"]}
       # Absinthe.Subscription.publish(StreamClosedCaptionerPhoenixWeb.Endpoint, %{ interim: "hello", final: "final" }, new_twitch_caption: "1")
       config(fn args, _ ->
-        {:ok, topic: args.channel_id}
+        if StreamClosedCaptionerPhoenixWeb.UserTracker.channel_connected?(args.channel_id) do
+          {:ok, topic: args.channel_id}
+        else
+          {:error, "channel is not active"}
+        end
       end)
     end
   end

--- a/test/stream_closed_captioner_phoenix_web/channels/user_tracker_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/channels/user_tracker_test.exs
@@ -41,8 +41,10 @@ defmodule StreamClosedCaptionerPhoenixWeb.UserTrackerTest do
   test "channel_connected?/1 returns true when a UserTracker entry exists" do
     test_pid = self()
     on_exit(fn -> UserTracker.untrack(test_pid, "active_channels", "uid-connected") end)
-    UserTracker.track(self(), "active_channels", "uid-connected", %{last_publish: 0})
+    # Empty metadata matches what CaptionsChannel.after_join actually tracks on join
+    UserTracker.track(self(), "active_channels", "uid-connected", %{})
     assert UserTracker.channel_connected?("uid-connected") == true
+    refute UserTracker.channel_active?("uid-connected")
   end
 
   test "channel_connected?/1 returns false when no UserTracker entry exists" do

--- a/test/stream_closed_captioner_phoenix_web/channels/user_tracker_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/channels/user_tracker_test.exs
@@ -37,4 +37,24 @@ defmodule StreamClosedCaptionerPhoenixWeb.UserTrackerTest do
 
     assert UserTracker.channel_active?("123") == true
   end
+
+  test "channel_connected?/1 returns true when a UserTracker entry exists" do
+    test_pid = self()
+    on_exit(fn -> UserTracker.untrack(test_pid, "active_channels", "uid-connected") end)
+    UserTracker.track(self(), "active_channels", "uid-connected", %{last_publish: 0})
+    assert UserTracker.channel_connected?("uid-connected") == true
+  end
+
+  test "channel_connected?/1 returns false when no UserTracker entry exists" do
+    assert UserTracker.channel_connected?("uid-never-tracked") == false
+  end
+
+  test "channel_connected?/1 returns true even when last_publish is stale (>300s ago)" do
+    test_pid = self()
+    stale_time = System.system_time(:second) - 400
+    on_exit(fn -> UserTracker.untrack(test_pid, "active_channels", "uid-stale") end)
+    UserTracker.track(self(), "active_channels", "uid-stale", %{last_publish: stale_time})
+    assert UserTracker.channel_connected?("uid-stale") == true
+    assert UserTracker.channel_active?("uid-stale") == false
+  end
 end

--- a/test/stream_closed_captioner_phoenix_web/schema/subscriptions_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/schema/subscriptions_test.exs
@@ -1,13 +1,14 @@
 defmodule StreamClosedCaptionerPhoenixWeb.Schema.SubscriptionsTest do
   # async: false required — tests mutate global UserTracker state (Phoenix.Tracker GenServer)
-  use StreamClosedCaptionerPhoenixWeb.ChannelCase
+  use StreamClosedCaptionerPhoenixWeb.ChannelCase, async: false
 
   alias StreamClosedCaptionerPhoenixWeb.UserTracker
 
   setup_all do
-    # Warm up the Absinthe pipeline so the first test does not time out waiting
-    # for lazy code loading. Absinthe.Test.prime/1 is blocked by
-    # AuthorizedIntrospection in non-dev envs, so we run __typename instead.
+    # Run once per module (not per test) to warm up the Absinthe pipeline so the
+    # first subscription test does not time out waiting for lazy code loading.
+    # Absinthe.Test.prime/1 is blocked by AuthorizedIntrospection in non-dev
+    # envs, so we use __typename (not schema introspection) instead.
     Absinthe.run("{ __typename }", StreamClosedCaptionerPhoenixWeb.Schema)
     :ok
   end
@@ -36,7 +37,8 @@ defmodule StreamClosedCaptionerPhoenixWeb.Schema.SubscriptionsTest do
     test_pid = self()
     on_exit(fn -> UserTracker.untrack(test_pid, "active_channels", channel_id) end)
 
-    UserTracker.track(self(), "active_channels", channel_id, %{last_publish: 0})
+    # Empty metadata matches what CaptionsChannel.after_join actually tracks on join
+    UserTracker.track(self(), "active_channels", channel_id, %{})
 
     {ref, _socket} = subscribe_to_captions(channel_id)
     assert_reply ref, :ok, %{subscriptionId: _}
@@ -58,6 +60,6 @@ defmodule StreamClosedCaptionerPhoenixWeb.Schema.SubscriptionsTest do
     channel_id = "sub-never-tracked-uid"
 
     {ref, _socket} = subscribe_to_captions(channel_id)
-    assert_reply ref, :error, %{errors: _}
+    assert_reply ref, :error, %{errors: [%{message: "channel is not connected"}]}
   end
 end

--- a/test/stream_closed_captioner_phoenix_web/schema/subscriptions_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/schema/subscriptions_test.exs
@@ -1,0 +1,63 @@
+defmodule StreamClosedCaptionerPhoenixWeb.Schema.SubscriptionsTest do
+  # async: false required — tests mutate global UserTracker state (Phoenix.Tracker GenServer)
+  use StreamClosedCaptionerPhoenixWeb.ChannelCase
+
+  alias StreamClosedCaptionerPhoenixWeb.UserTracker
+
+  setup_all do
+    # Warm up the Absinthe pipeline so the first test does not time out waiting
+    # for lazy code loading. Absinthe.Test.prime/1 is blocked by
+    # AuthorizedIntrospection in non-dev envs, so we run __typename instead.
+    Absinthe.run("{ __typename }", StreamClosedCaptionerPhoenixWeb.Schema)
+    :ok
+  end
+
+  @subscription """
+  subscription($channelId: ID!) {
+    newTwitchCaption(channelId: $channelId) {
+      final
+      interim
+    }
+  }
+  """
+
+  defp subscribe_to_captions(channel_id) do
+    socket =
+      StreamClosedCaptionerPhoenixWeb.UserSocket
+      |> socket("viewer", %{__absinthe_schema__: StreamClosedCaptionerPhoenixWeb.Schema})
+
+    {:ok, _, socket} = subscribe_and_join(socket, Absinthe.Phoenix.Channel, "__absinthe__:control")
+    ref = push(socket, "doc", %{"query" => @subscription, "variables" => %{"channelId" => channel_id}})
+    {ref, socket}
+  end
+
+  test "new_twitch_caption subscription is accepted when channel has a UserTracker entry" do
+    channel_id = "sub-connected-uid"
+    test_pid = self()
+    on_exit(fn -> UserTracker.untrack(test_pid, "active_channels", channel_id) end)
+
+    UserTracker.track(self(), "active_channels", channel_id, %{last_publish: 0})
+
+    {ref, _socket} = subscribe_to_captions(channel_id)
+    assert_reply ref, :ok, %{subscriptionId: _}
+  end
+
+  test "new_twitch_caption subscription is accepted when connected but last_publish is stale (>300s)" do
+    channel_id = "sub-stale-uid"
+    test_pid = self()
+    on_exit(fn -> UserTracker.untrack(test_pid, "active_channels", channel_id) end)
+
+    stale_time = System.system_time(:second) - 400
+    UserTracker.track(self(), "active_channels", channel_id, %{last_publish: stale_time})
+
+    {ref, _socket} = subscribe_to_captions(channel_id)
+    assert_reply ref, :ok, %{subscriptionId: _}
+  end
+
+  test "new_twitch_caption subscription is rejected when channel has no UserTracker entry" do
+    channel_id = "sub-never-tracked-uid"
+
+    {ref, _socket} = subscribe_to_captions(channel_id)
+    assert_reply ref, :error, %{errors: _}
+  end
+end


### PR DESCRIPTION
## Summary
Add validation to the `newTwitchCaption` GraphQL subscription to ensure a channel has an active `UserTracker` entry before allowing subscription. This prevents subscriptions to channels that are not currently connected or streaming.

## Changes
- **`UserTracker.channel_connected?/1`** — New function to check if a channel has any active tracker entry, regardless of publish recency. Returns `true` if the channel exists in the tracker, `false` otherwise.
- **`Schema.subscription(:new_twitch_caption)`** — Updated config to validate channel connection before accepting subscriptions. Returns `{:error, "channel is not active"}` if the channel is not tracked.
- **Test coverage** — Added comprehensive tests for the new function and subscription behavior:
  - `channel_connected?/1` returns `true` when a tracker entry exists
  - `channel_connected?/1` returns `false` when no entry exists
  - `channel_connected?/1` returns `true` even with stale `last_publish` (>300s), distinguishing it from `channel_active?/1`
  - Subscription acceptance/rejection based on tracker presence

## Implementation Details
- `channel_connected?` differs from the existing `channel_active?` — the latter checks both presence *and* recent publish activity (within 300s), while the former only checks presence. This allows subscriptions to channels that are connected but haven't published captions recently.
- Tests use `UserTracker.track/untrack` with `on_exit` cleanup to avoid polluting global tracker state across test runs.
- Subscription tests warm up the Absinthe pipeline in `setup_all` to prevent timeout on first test execution.

https://claude.ai/code/session_01Nk2nXCFg9WD3Xcxm36LhPt