### PR TITLE
Add Azure Cognitive HTTP test coverage and same-language short-circuit

### DIFF
--- a/lib/stream_closed_captioner_phoenix/services/azure/cognitive.ex
+++ b/lib/stream_closed_captioner_phoenix/services/azure/cognitive.ex
@@ -9,22 +9,24 @@ defmodule Azure.Cognitive do
   alias Ecto.UUID
   @behaviour Azure.CognitiveProvider
 
+  @endpoint "https://api.cognitive.microsofttranslator.com/translate"
+
   @impl Azure.CognitiveProvider
 
   @trace :translate
   def translate(from_language \\ "en", to_languages, text)
       when is_list(to_languages) and is_binary(text) do
-    language_tuple_list =
-      Enum.flat_map(to_languages, fn lang ->
-        [code | _] = String.split(from_language, "-")
+    [from_code | _] = String.split(from_language, "-")
+    language_tuple_list = to_languages |> Enum.reject(&(&1 == from_code)) |> Enum.map(&{:to, &1})
 
-        if lang != code do
-          [{:to, lang}]
-        else
-          []
-        end
-      end)
+    if language_tuple_list == [] do
+      {:ok, Translations.new(%{translations: []})}
+    else
+      do_translate(from_language, to_languages, language_tuple_list, text)
+    end
+  end
 
+  defp do_translate(from_language, to_languages, language_tuple_list, text) do
     params = [
       {"api-version", "3.0"},
       {:profanityAction, "Marked"},
@@ -47,9 +49,7 @@ defmodule Azure.Cognitive do
 
     NewRelic.add_attributes(translate: %{from: from_language, to: to_languages, text: text})
 
-    url =
-      "https://api.cognitive.microsofttranslator.com/translate"
-      |> encode_url_and_params(params)
+    url = endpoint() |> encode_url_and_params(params)
 
     case HTTPoison.post(url, body, headers) do
       {:ok, %{body: raw_body}} ->
@@ -71,4 +71,8 @@ defmodule Azure.Cognitive do
         {:error, {:http, reason}}
     end
   end
+
+  @doc false
+  def endpoint,
+    do: Application.get_env(:stream_closed_captioner_phoenix, :azure_endpoint, @endpoint)
 end

--- a/lib/stream_closed_captioner_phoenix_web/components/admin_components.ex
+++ b/lib/stream_closed_captioner_phoenix_web/components/admin_components.ex
@@ -30,7 +30,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.AdminComponents do
 
   def admin_search(assigns) do
     ~H"""
-    <form phx-submit="search" phx-change="search" class="mb-4">
+    <form id="admin-search-form" phx-submit="search" phx-change="search" class="mb-4">
       <div class="relative max-w-sm">
         <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <svg

--- a/lib/stream_closed_captioner_phoenix_web/components/tables.ex
+++ b/lib/stream_closed_captioner_phoenix_web/components/tables.ex
@@ -55,7 +55,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Components.Tables do
     assigns = assign(assigns, form: Phoenix.Component.to_form(meta), meta: nil)
 
     ~H"""
-    <.form for={@form} phx-change="update-filter" class={@class}>
+    <.form for={@form} id="filter-form" phx-change="update-filter" class={@class}>
       <Flop.Phoenix.filter_fields :let={i} form={@form} fields={@fields}>
         <.input
           placeholder={"Filter by #{i.label}"}

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/announcement_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/announcement_live/form_component.ex
@@ -53,6 +53,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.AnnouncementLive.FormComponent d
       <.form
         :let={f}
         for={@changeset}
+        id="announcement-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/bits_balance_debit_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/bits_balance_debit_live/form_component.ex
@@ -44,6 +44,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.BitsBalanceDebitLive.FormCompone
       <.form
         :let={f}
         for={@changeset}
+        id="bits-balance-debit-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/bits_balance_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/bits_balance_live/form_component.ex
@@ -44,6 +44,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.BitsBalanceLive.FormComponent do
       <.form
         :let={f}
         for={@changeset}
+        id="bits-balance-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/bits_transaction_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/bits_transaction_live/form_component.ex
@@ -44,6 +44,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.BitsTransactionLive.FormComponen
       <.form
         :let={f}
         for={@changeset}
+        id="bits-transaction-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/eventsub_subscription_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/eventsub_subscription_live/form_component.ex
@@ -45,6 +45,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.EventsubSubscriptionLive.FormCom
       <.form
         :let={f}
         for={@changeset}
+        id="eventsub-subscription-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/message_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/message_live/form_component.ex
@@ -44,6 +44,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.MessageLive.FormComponent do
       <.form
         :let={f}
         for={@changeset}
+        id="message-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/stream_settings_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/stream_settings_live/form_component.ex
@@ -44,6 +44,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.StreamSettingsLive.FormComponent
       <.form
         :let={f}
         for={@changeset}
+        id="stream-settings-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/transcript_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/transcript_live/form_component.ex
@@ -44,6 +44,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.TranscriptLive.FormComponent do
       <.form
         :let={f}
         for={@changeset}
+        id="transcript-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/translate_language_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/translate_language_live/form_component.ex
@@ -44,6 +44,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.TranslateLanguageLive.FormCompon
       <.form
         :let={f}
         for={@changeset}
+        id="translate-language-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/user_live/form_component.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/user_live/form_component.ex
@@ -53,6 +53,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.UserLive.FormComponent do
       <.form
         :let={f}
         for={@changeset}
+        id="user-form"
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"

--- a/test/stream_closed_captioner_phoenix/services/azure/cognitive_test.exs
+++ b/test/stream_closed_captioner_phoenix/services/azure/cognitive_test.exs
@@ -1,0 +1,205 @@
+defmodule Azure.CognitiveTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
+
+  alias Azure.Cognitive.Translation
+  alias Azure.Cognitive.Translations
+
+  describe "endpoint/0" do
+    test "defaults to the production Azure Translator endpoint when no override is configured" do
+      assert Azure.Cognitive.endpoint() ==
+               "https://api.cognitive.microsofttranslator.com/translate"
+    end
+  end
+
+  describe "Translation.new/1" do
+    test "sets text and looks up name from translatable_languages for a known code" do
+      translation = Translation.new(%{"to" => "es", "text" => "Hola"})
+
+      assert %Translation{text: "Hola", name: "Spanish"} = translation
+    end
+
+    test "returns name: nil when the language code is not in translatable_languages" do
+      translation = Translation.new(%{"to" => "xx", "text" => "???"})
+
+      assert %Translation{text: "???", name: nil} = translation
+    end
+  end
+
+  describe "Translations.new/1" do
+    test "builds a map keyed by language code from a multi-entry translations list" do
+      translations =
+        Translations.new(%{
+          "translations" => [
+            %{"to" => "es", "text" => "Hola"},
+            %{"to" => "fr", "text" => "Bonjour"}
+          ]
+        })
+
+      assert %Translations{
+               translations: %{
+                 "es" => %Translation{text: "Hola", name: "Spanish"},
+                 "fr" => %Translation{text: "Bonjour", name: "French"}
+               }
+             } = translations
+    end
+
+    test "returns an empty map for an empty translations list" do
+      translations = Translations.new(%{"translations" => []})
+
+      assert %Translations{translations: %{}} = translations
+    end
+
+    test "collapses an entry missing the \"to\" key under a nil map key" do
+      translations =
+        Translations.new(%{
+          "translations" => [%{"text" => "no code here"}]
+        })
+
+      assert %Translations{translations: %{nil => %Translation{text: "no code here"}}} =
+               translations
+    end
+  end
+
+  describe "translate/3 — short-circuits" do
+    test "returns empty translations without an HTTP call when the only target matches the source language" do
+      assert {:ok, %Translations{translations: translations}} =
+               Azure.Cognitive.translate("en-US", ["en"], "Hello")
+
+      assert translations == %{}
+    end
+
+    test "returns empty translations without an HTTP call for empty to_languages" do
+      assert {:ok, %Translations{translations: translations}} =
+               Azure.Cognitive.translate("en", [], "Hello")
+
+      assert translations == %{}
+    end
+  end
+
+  describe "translate/3 — HTTP" do
+    setup do
+      bypass = Bypass.open()
+
+      System.put_env("COGNITIVE_SERVICE_KEY", "test-azure-key")
+
+      Application.put_env(
+        :stream_closed_captioner_phoenix,
+        :azure_endpoint,
+        "http://localhost:#{bypass.port}/translate"
+      )
+
+      on_exit(fn ->
+        System.delete_env("COGNITIVE_SERVICE_KEY")
+        Application.delete_env(:stream_closed_captioner_phoenix, :azure_endpoint)
+      end)
+
+      {:ok, bypass: bypass}
+    end
+
+    test "parses a well-formed response into a Translations struct keyed by language code", %{
+      bypass: bypass
+    } do
+      response_body =
+        Jason.encode!([
+          %{
+            "translations" => [
+              %{"to" => "es", "text" => "Hola"},
+              %{"to" => "fr", "text" => "Bonjour"}
+            ]
+          }
+        ])
+
+      Bypass.expect_once(bypass, "POST", "/translate", fn conn ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(200, response_body)
+      end)
+
+      assert {:ok, %Translations{translations: translations}} =
+               Azure.Cognitive.translate("en", ["es", "fr"], "Hello")
+
+      assert %Translation{text: "Hola", name: "Spanish"} = translations["es"]
+      assert %Translation{text: "Bonjour", name: "French"} = translations["fr"]
+    end
+
+    test "sends the API key as a header, never in the query string", %{bypass: bypass} do
+      response_body = Jason.encode!([%{"translations" => [%{"to" => "es", "text" => "Hola"}]}])
+
+      Bypass.expect_once(bypass, "POST", "/translate", fn conn ->
+        assert [api_key_header] = get_req_header(conn, "ocp-apim-subscription-key")
+        assert api_key_header == "test-azure-key"
+        refute conn.query_string =~ "test-azure-key"
+        refute conn.query_string =~ "Ocp-Apim"
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(200, response_body)
+      end)
+
+      assert {:ok, _translations} = Azure.Cognitive.translate("en", ["es"], "Hello")
+    end
+
+    test "returns :unexpected_json when the top-level JSON is not a single-element list", %{
+      bypass: bypass
+    } do
+      Bypass.expect_once(bypass, "POST", "/translate", fn conn ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(200, Jason.encode!(%{"error" => "nope"}))
+      end)
+
+      assert {:error, {:unexpected_json, _other}} =
+               Azure.Cognitive.translate("en", ["es"], "Hello")
+    end
+
+    test "returns :json_decode when the response body is not valid JSON", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/translate", fn conn ->
+        conn
+        |> put_resp_content_type("text/html")
+        |> send_resp(200, "<html>gateway error</html>")
+      end)
+
+      assert {:error, {:json_decode, %Jason.DecodeError{}}} =
+               Azure.Cognitive.translate("en", ["es"], "Hello")
+    end
+
+    test "returns :http error when the server is unreachable", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      assert {:error, {:http, :econnrefused}} = Azure.Cognitive.translate("en", ["es"], "Hello")
+    end
+
+    test "omits the source language from the to= params on a partial match", %{bypass: bypass} do
+      response_body = Jason.encode!([%{"translations" => [%{"to" => "es", "text" => "Hola"}]}])
+
+      Bypass.expect_once(bypass, "POST", "/translate", fn conn ->
+        query = URI.decode_query(conn.query_string)
+        assert query["to"] == "es"
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(200, response_body)
+      end)
+
+      assert {:ok, _translations} = Azure.Cognitive.translate("en", ["es", "en"], "Hello")
+    end
+
+    test "keeps a target language whose casing differs from the source (case-sensitive match)", %{
+      bypass: bypass
+    } do
+      response_body = Jason.encode!([%{"translations" => [%{"to" => "EN", "text" => "Hello"}]}])
+
+      Bypass.expect_once(bypass, "POST", "/translate", fn conn ->
+        assert conn.query_string =~ "to=EN"
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(200, response_body)
+      end)
+
+      assert {:ok, _translations} = Azure.Cognitive.translate("en-US", ["EN"], "Hello")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Azure.Cognitive` — the default translation path for every user without the `gemini_translations` feature flag — had zero dedicated tests and a hardcoded base URL, unlike its `Gemini.Cognitive` sibling which already has full Bypass-based HTTP test coverage. This PR brings the two providers to parity: it extracts the Azure Translator base URL into a config-overridable `endpoint/0` helper (mirroring the existing Gemini pattern) so it can be pointed at a `Bypass` server in tests, and adds `test/stream_closed_captioner_phoenix/services/azure/cognitive_test.exs` covering the endpoint default, `Translation.new/1`/`Translations.new/1` struct parsing, and `translate/3`'s full HTTP behavior (happy path, API key delivered via header not query string, unexpected JSON shape, JSON decode failure, network errors, and same/different/case-sensitive language filtering).

Closes #377

## Implementation notes

- **Same-language short-circuit added, per the issue's follow-up discussion.** The original issue only asked for tests characterizing *existing* behavior, but `@talk2MeGooseman` clarified in a follow-up comment that when every "to" language matches the source language, `translate/3` should skip the HTTP call entirely so a user configuration mistake doesn't burn translation credits. `Azure.Cognitive.translate/3` now mirrors `Gemini.Cognitive.translate/3`'s existing short-circuit: it filters `to_languages` against the source language first, and if nothing remains (including the case where `to_languages` was empty to begin with), it returns `{:ok, %Translations{translations: %{}}}` without ever calling `HTTPoison.post`. The HTTP-making logic was extracted into a private `do_translate/4` to keep `translate/3` readable.
- **`Translations.new/1`'s handling of a translation entry missing the `"to"` key** is characterized as-is (it collapses under a `nil` map key, discarding all but the last such entry) rather than changed — this was flagged in the plan as a possible pre-existing data-loss bug, but fixing it is out of scope for a test-coverage PR and wasn't part of the resolved follow-up. Test 6 documents current behavior explicitly so any future fix is a deliberate, visible change.
- **`endpoint/0` is public (`@doc false`)** rather than private, unlike Gemini's private `endpoint/0`, specifically so the default-value test (test 1) can assert on it directly without making a real network call.

## Test coverage

15 new tests in `azure/cognitive_test.exs`:
- `endpoint/0` default value
- `Translation.new/1`: known-language lookup, unknown-language `nil` name
- `Translations.new/1`: multi-entry map building, empty list, missing-`"to"`-key characterization
- `translate/3` short-circuits: same-language target, empty `to_languages`
- `translate/3` HTTP (via Bypass): happy path, API key header (never in query string), unexpected JSON shape, JSON decode failure, network unreachable, partial-match language filtering, case-sensitive language matching

Full suite: 448 tests, 0 failures. `mix format --check-formatted`, `mix lint` (Credo), and `mix security` (Sobelow) all pass with no new issues in the changed files. Coverage on `lib/stream_closed_captioner_phoenix/services/azure/cognitive.ex`: 94.1%.

## Open questions resolved

- **Should `Azure.Cognitive.translate/3` gain a Gemini-style short-circuit?** Yes — resolved by `@talk2MeGooseman`'s follow-up comment on the issue ("If the 'to' language is the same as the source language, it should guard against translation activation so that they don't lose credits for a mistake."). Implemented as described above.
- **Is the missing-`"to"`-key collapse in `Translations.new/1` a bug?** Left unresolved/out of scope — characterized with a test (test 6) rather than fixed, per the plan's guidance not to expand scope silently.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BFV1TW2qGa3hbKp9Wk9h7b)_