### PR TITLE
Add co-streamer guest captions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,10 @@ Coverage: `mix coveralls.html`
    - `:zoom` → sends to Zoom live captions API
    - `:default` → broadcasts on `transcript:1` topic
 
+### Co-streamer guest captions
+
+Hosts invite guests via per-guest shareable links (`Costream` context, `costream_guests` table). The link token (`Phoenix.Token`, no expiry) only carries the guest id; revocation/mute/name live on the DB record. Guests open `/costream/:token` (no account), transcribe in-browser (Web Speech API), and publish over `CostreamChannel` (`costream:HOST_USER_ID`). Guest text gets the **host's censoring only** — no pirate mode, no translations — then fans out to the `new_costream_caption` GraphQL subscription (separate from `new_twitch_caption` so pre-costream extension bundles never see guest text), the OBS overlay topic (finals only, name-prefixed), and the host's monitor topic (`costream_monitor:HOST_ID`, consumed by the `/users/costream` LiveView for live text + mute/kick). Publishing is rate limited per guest (Hammer), gated on the host being active in `UserTracker`, the `:costream_captions` feature flag, and the `stream_settings.costream_enabled` kill switch. Mute/kick reach guest channel processes via `Endpoint.broadcast/3` control events (`guest_muted`/`guest_kicked`), intercepted in the channel.
+
 ### Translation / Billing
 
 Translation uses Azure Cognitive Services. Two paths exist in `CaptionsPipeline.Translations.maybe_translate/3`:

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "memory": {
+      "type": "http",
+      "url": "${WINDMILL_MCP_URL}",
+      "headers": {
+        "Authorization": "Bearer ${WINDMILL_MCP_TOKEN}"
+      }
+    }
+  }
+}

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -4,6 +4,31 @@ Active decisions shape proj. New → `.squad/decisions/inbox/`. Scribe merge.
 
 ---
 
+## 2026-07-12 — Co-Streamer Guest Captions: Separate Subscription + Slim Pipeline
+
+**By:** Erik Guzman (Owner) | **Status:** Active
+
+Guest (co-streamer) captions = parallel path, never through existing one.
+Full ADR: `docs/adr/0001-costream-guest-captions.md`.
+
+- Guest text NEVER rides `new_twitch_caption` — old extension bundles hardcode
+  that selection set, would render guests unattributed. Separate
+  `new_costream_caption` subscription only.
+- Guest pipeline = host censoring only. No pirate, no translate — per-guest
+  cost ~zero, cap 4 concurrent guests.
+- Auth = per-guest signed link (`Costream.guest_token/1`) + live DB state
+  (revoked/muted). Token carries guest id only; revoke/mute instant, no token
+  rotation. No guest accounts.
+- Publish gates: host actively captioning (`UserTracker`) +
+  `:costream_captions` flag + `costream_enabled` kill switch + per-guest
+  Hammer rate limit (15/sec).
+- Mute/kick = `Endpoint.broadcast/3` control events intercepted in
+  `CostreamChannel` (cluster-safe).
+- OBS overlay: guest finals only, name-prefixed. Interim dropped (single
+  interim line can't interleave speakers).
+
+---
+
 ## 2026-04-21 — Pragmatic Programmer Methodologies as Team Standard
 
 **By:** Erik Guzman (Owner) | **Status:** Active

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ Supervised children (`application.ex`): libcluster, Repo, Telemetry, PubSub, End
 The **caption pipeline** is the product:
 client transcribes → `CaptionsChannel` (Phoenix Channel `captions:USER_ID`) → `CaptionsPipeline` (censor → pirate → translate) → fan-out to Twitch (via Absinthe subscription `new_twitch_caption`), Zoom live captions API, or `transcript:1` PubSub topic. See copilot-instructions for full detail.
 
+**Co-streamer guest captions** ride a parallel, slimmer path: per-guest shareable link (`Costream` context) → `/costream/:token` guest page → `CostreamChannel` (`costream:HOST_ID`, rate limited, gated on host activity + `:costream_captions` flag + `costream_enabled` kill switch) → host-settings censoring only (no pirate/translate) → separate `new_costream_caption` subscription + OBS overlay + host monitor LiveView (`/users/costream`). The separate subscription is deliberate: old extension bundles hardcode the `new_twitch_caption` selection set and must never receive unattributed guest text.
+
 ## Project-specific quirks to know
 
 - **Migration table is renamed.** `config/dev.exs` sets `migration_source: "ecto_schema_migrations"` — the app was migrated from a Rails origin that owns `schema_migrations`. Don't change this; new migrations should keep using `mix ecto.gen.migration ...`.

--- a/assets/js/controllers/costream_controller.js
+++ b/assets/js/controllers/costream_controller.js
@@ -1,0 +1,183 @@
+import SpeechRecognitionHandler from "../SpeechRecognitionHandler"
+import { isBrowserCompatible } from "../utils"
+import { Controller } from "@hotwired/stimulus"
+import { Socket } from "phoenix"
+import debugLogger from "debug"
+
+const debug = debugLogger("cc:costream-controller")
+
+const BADGE_BASE = "rounded-full px-3 py-1"
+
+/**
+ * Guest ("co-streamer") caption dashboard.
+ *
+ * Unlike the host dashboard, this page has no logged-in user: the socket is
+ * authenticated with the signed guest link token, and the channel topic is
+ * the HOST's costream topic. The server pushes control events the UI must
+ * honor: "muted" (stop forwarding indicator), "kicked" (link revoked live),
+ * and "host_status" (whether the host is actively captioning).
+ */
+export default class extends Controller {
+  static targets = [
+    "start",
+    "warning",
+    "kicked",
+    "connectionBadge",
+    "hostBadge",
+    "mutedBadge",
+    "language",
+    "finalOutput",
+    "interimOutput",
+  ]
+
+  static values = {
+    token: String,
+    hostId: String,
+    language: String,
+  }
+
+  removeEvents = []
+  kicked = false
+
+  connect() {
+    if (!isBrowserCompatible()) {
+      this.warningTarget.classList.remove("hidden")
+      return
+    }
+
+    this.speechRecognitionHandler = new SpeechRecognitionHandler()
+    this.speechRecognitionHandler.setLanguage(
+      this.languageValue || "en-US"
+    )
+
+    this.removeEvents.push(
+      this.speechRecognitionHandler.onEvent("started", this.recognitionStarted),
+      this.speechRecognitionHandler.onEvent("stopped", this.recognitionStopped),
+      this.speechRecognitionHandler.onEvent("interim", this.publishSpeech),
+      this.speechRecognitionHandler.onEvent("final", this.publishSpeech)
+    )
+
+    this.joinChannel()
+  }
+
+  disconnect() {
+    this.removeEvents.forEach((remove) => remove())
+    if (this.speechRecognitionHandler) this.speechRecognitionHandler.stop()
+    if (this.socket) this.socket.disconnect()
+  }
+
+  joinChannel() {
+    this.socket = new Socket("/socket", {
+      params: { costreamToken: this.tokenValue },
+    })
+    this.socket.connect()
+
+    this.socket.onError(() => this.setConnectionBadge("error"))
+
+    this.channel = this.socket.channel(`costream:${this.hostIdValue}`, {})
+
+    this.channel.on("host_status", ({ active }) => this.setHostBadge(active))
+    this.channel.on("muted", ({ muted }) => this.setMuted(muted))
+    this.channel.on("kicked", () => this.handleKicked())
+
+    this.channel
+      .join()
+      .receive("ok", ({ muted }) => {
+        debug("joined costream channel")
+        this.setConnectionBadge("connected")
+        this.setMuted(muted)
+        this.startTarget.disabled = false
+      })
+      .receive("error", (resp) => {
+        debug("unable to join", resp)
+        this.setConnectionBadge("error")
+      })
+  }
+
+  toggleCaptions = () => {
+    if (this.kicked) return
+    this.speechRecognitionHandler.toggleOn()
+  }
+
+  languageChanged = () => {
+    this.speechRecognitionHandler.setLanguage(this.languageTarget.value)
+  }
+
+  publishSpeech = (data) => {
+    if (this.kicked) return
+
+    // confidence is dashboard-only on the host page; guests don't send it
+    const { confidence: _confidence, ...speechData } = data
+
+    this.channel
+      .push("publish", speechData, 5000)
+      .receive("ok", (captions) => this.displayCaptions(captions))
+      .receive("error", ({ reason }) => this.handlePublishError(reason))
+  }
+
+  handlePublishError = (reason) => {
+    debug("publish rejected", reason)
+    switch (reason) {
+      case "muted":
+        this.setMuted(true)
+        break
+      case "host_offline":
+        this.setHostBadge(false)
+        break
+      default:
+        break
+    }
+  }
+
+  displayCaptions = (captions) => {
+    // A successful publish implies the host is live and we're not muted.
+    this.setHostBadge(true)
+    this.interimOutputTarget.textContent = captions.interim
+    if (captions.final) this.finalOutputTarget.textContent = captions.final
+  }
+
+  recognitionStarted = () => {
+    window.onbeforeunload = () =>
+      "Navigating away will stop your co-stream captions, are you sure?"
+    this.startTarget.textContent = "Stop Captions"
+  }
+
+  recognitionStopped = () => {
+    window.onbeforeunload = null
+    this.startTarget.textContent = "Start Captions"
+  }
+
+  setConnectionBadge(state) {
+    const badge = this.connectionBadgeTarget
+    if (state === "connected") {
+      badge.className = `${BADGE_BASE} bg-green-200 text-green-800`
+      badge.textContent = "Connected"
+    } else {
+      badge.className = `${BADGE_BASE} bg-red-200 text-red-800`
+      badge.textContent = "Connection problem — retrying…"
+    }
+  }
+
+  setHostBadge(active) {
+    const badge = this.hostBadgeTarget
+    if (active) {
+      badge.className = `${BADGE_BASE} bg-green-200 text-green-800`
+      badge.textContent = "Streamer is captioning"
+    } else {
+      badge.className = `${BADGE_BASE} bg-gray-200 text-gray-700`
+      badge.textContent = "Streamer offline — captions paused"
+    }
+  }
+
+  setMuted(muted) {
+    this.mutedBadgeTarget.classList.toggle("hidden", !muted)
+  }
+
+  handleKicked() {
+    this.kicked = true
+    this.speechRecognitionHandler.stop()
+    this.kickedTarget.classList.remove("hidden")
+    this.startTarget.disabled = true
+    this.socket.disconnect()
+  }
+}

--- a/assets/js/controllers/index.js
+++ b/assets/js/controllers/index.js
@@ -1,4 +1,5 @@
 export { default as CaptionsController } from './captions_controller';
+export { default as CostreamController } from './costream_controller';
 export { default as DarkmodeController } from './darkmode_controller'
 export { default as DropdownController } from './dropdown_controller';
 export { default as ObsController } from './obs_controller';

--- a/assets/js/stimulus.js
+++ b/assets/js/stimulus.js
@@ -1,5 +1,6 @@
 import { Application } from '@hotwired/stimulus';
 import { CaptionsController } from './controllers';
+import { CostreamController } from './controllers';
 import { DropdownController } from './controllers';
 import { DarkmodeController } from './controllers';
 import { ObsController } from './controllers';
@@ -11,6 +12,7 @@ import { ZoomController } from './controllers';
 window.Stimulus = Application.start();
 
 Stimulus.register('captions', CaptionsController);
+Stimulus.register('costream', CostreamController);
 Stimulus.register('darkmode', DarkmodeController);
 Stimulus.register('dropdown', DropdownController);
 Stimulus.register('obs', ObsController);

--- a/docs/adr/0001-costream-guest-captions.md
+++ b/docs/adr/0001-costream-guest-captions.md
@@ -1,0 +1,167 @@
+---
+title: "ADR-0001: Co-Streamer Guest Captions via Separate Channel and Subscription"
+status: "Accepted"
+date: "2026-07-12"
+authors: "Erik Guzman (Owner)"
+tags: ["architecture", "decision", "captions", "costream", "twitch-extension"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0001: Co-Streamer Guest Captions via Separate Channel and Subscription
+
+## Status
+
+Accepted
+
+## Context
+
+Streamers co-stream with guests (podcasts, squad streams, interviews), but only
+the primary streamer's speech is captioned. Guests' words are invisible to
+viewers who rely on captions.
+
+Forces at play:
+
+- **Backwards compatibility is structural, not optional.** Released Twitch
+  extension bundles are frozen JavaScript with the `newTwitchCaption` GraphQL
+  selection set (`interim`, `final`, `translations`) hardcoded. Whatever
+  arrives on that subscription renders as the streamer's own caption line,
+  unattributed. Twitch controls version rollout; old bundles stay live for
+  weeks or longer.
+- **Performance.** The caption pipeline runs per utterance. Translations cost
+  money (Azure/Gemini, bits-gated) and add a 3s-timeout async hop; pirate mode
+  is cosmetic. Multiplying either by N concurrent guests multiplies cost and
+  latency for no product requirement.
+- **Trust.** A guest link puts words on someone else's stream. The host must
+  keep unilateral, immediate control (mute, kick, global off), and guests must
+  not be able to caption to an audience while the host is not even streaming.
+- **Low friction.** Podcast guests are often one-off participants without SCC
+  accounts; requiring registration or Twitch OAuth would kill adoption.
+- **Existing plumbing.** The app already has Phoenix Channels, Absinthe
+  subscriptions keyed by Twitch channel id, a presence tracker of actively
+  captioning channels (`UserTracker`), a supervised-but-unused Hammer rate
+  limiter, FunWithFlags, and two shareable-token precedents
+  (`caption_source_token`, the admin local-extension-testing JWT).
+
+## Decision
+
+Add a parallel, slimmer guest caption path rather than extending the existing
+one:
+
+- **Per-guest signed links** (`Costream` context, `costream_guests` table).
+  The `Phoenix.Token` link carries only the guest id; authorization state
+  (revocation, mute, host-assigned display name) lives on the DB row and is
+  re-checked on socket connect, channel join, and via live control events —
+  so host actions are immediate and tokens never need rotating. No guest
+  accounts.
+- **Dedicated `CostreamChannel`** (`costream:HOST_ID`) with two roles: guest
+  sockets (link-token auth) may publish; the host's user socket joins
+  read-only. Guest publishes are rate limited per guest (Hammer, 15/sec),
+  gated on the host actively captioning (`UserTracker`), the
+  `:costream_captions` feature flag, and a `costream_enabled` kill switch on
+  stream settings.
+- **Slim pipeline path** `CaptionsPipeline.pipeline_to(:costream, host, msg)`:
+  the HOST's censoring settings only — no pirate mode, no translations.
+- **Separate GraphQL subscription** `new_costream_caption` (guest id, name,
+  interim, final). The existing `new_twitch_caption` payload is untouched, so
+  pre-costream extension bundles never receive guest text.
+- **Fan-out**: extension subscription + OBS overlay (finals only,
+  name-prefixed) + a host monitor PubSub topic feeding the `/users/costream`
+  LiveView (live text, connected state, mute/kick).
+- **Guest transcription in the guest's browser** via the free Web Speech API
+  (Chrome/Edge/Safari), reusing the dashboard's `SpeechRecognitionHandler`.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Old extension versions are provably unaffected — they cannot
+  select fields they don't query, and guest text never travels on their
+  subscription. No coordinated release needed between backend and extension.
+- **POS-002**: Guest cost scales near-zero: no translation/pirate spend, no
+  server-side speech-to-text, censoring is an in-process regex pass. Fan-out
+  is bounded by the 4-guest cap and per-guest rate limit.
+- **POS-003**: Host trust controls are immediate and cluster-safe: mute/kick
+  travel as `Endpoint.broadcast/3` control events intercepted by guest channel
+  processes on any node; revocation is a DB flag checked on every verify.
+- **POS-004**: Fault tolerant by construction — guests pause automatically
+  when the host stops captioning; a crashed guest channel unregisters from the
+  tracker; the whole feature can be killed per-host (settings toggle) or
+  globally (feature flag) without deploys.
+- **POS-005**: Reuses existing primitives (Channels, Absinthe topics keyed by
+  Twitch uid, Hammer, FunWithFlags, tracker), keeping new surface area small.
+
+### Negative
+
+- **NEG-001**: Viewers on old extension versions see no guest captions at all
+  (chosen over unattributed degradation); full experience requires a new
+  extension release and Twitch review.
+- **NEG-002**: Guest captions are never translated, so viewers watching a
+  translation language get mixed-language output (or hide guests) — a
+  deliberate performance trade-off surfaced as a viewer sub-toggle.
+- **NEG-003**: Web Speech API limits guests to Chrome/Edge/Safari and
+  quality varies by browser; the guest page must warn unsupported browsers.
+- **NEG-004**: Each guest publish reads stream settings + flag state
+  (mirroring the existing per-message pattern); at the 4-guest cap this
+  multiplies that per-utterance DB/cache load.
+- **NEG-005**: Anyone holding an unrevoked link can caption while the host is
+  live — the trust model is possession + host moderation, not identity.
+
+## Alternatives Considered
+
+### Publish guest text on the existing `new_twitch_caption` subscription
+
+- **ALT-001**: **Description**: Add guest fields to the existing payload
+  and/or publish guest events on the same topic, letting old clients degrade.
+- **ALT-002**: **Rejection Reason**: Old bundles render whatever arrives in
+  `final`/`interim` as the streamer's own words — strangers' unattributed text
+  on the host's stream is a trust failure, not graceful degradation.
+  Name-prefixing text inside `final` would pollute new clients' data,
+  translations, and dedup logic.
+
+### Require guest login (Twitch OAuth or SCC account)
+
+- **ALT-003**: **Description**: Authenticate guests as real users, giving
+  verified identity for attribution and abuse handling.
+- **ALT-004**: **Rejection Reason**: Kills the one-click podcast-guest flow;
+  host-assigned names on per-guest revocable links give equivalent practical
+  control (per-guest revoke/mute) without onboarding friction.
+
+### Server-side transcription for guests (Deepgram)
+
+- **ALT-005**: **Description**: Stream guest audio to the server and use the
+  existing Deepgram integration for higher-quality transcription.
+- **ALT-006**: **Rejection Reason**: The server-global `DEEPGRAM_TOKEN` means
+  the platform pays per guest audio-minute, unbounded by anything a host
+  controls; audio ingest also adds bandwidth and privacy surface. Browser Web
+  Speech is free and matches the host dashboard's default path.
+
+### Do nothing (guests keep talking uncaptioned)
+
+- **ALT-007**: **Description**: Leave co-streams single-speaker.
+- **ALT-008**: **Rejection Reason**: Accessibility gap is the product's core
+  problem statement; co-streaming is common and repeatedly requested.
+
+## Implementation Notes
+
+- **IMP-001**: Shipped across two repos on branch
+  `claude/costreamer-captions-stcu3m`: Phoenix (context, channel, pipeline
+  clause, GraphQL, guest page, host LiveView, overlay) and the extension
+  (subscription, speaker-tagged queue, viewer toggles).
+- **IMP-002**: Rollout: run the migration, enable `:costream_captions` via
+  `/feature-flags` (per-actor first, then globally), then release the updated
+  extension version. Backend can ship first safely.
+- **IMP-003**: Success criteria: guest publishes rejected when host inactive /
+  muted / kill-switched (channel test coverage); no change in
+  `new_twitch_caption` payload shape; extension bundle diff limited to
+  additive subscription + render path.
+- **IMP-004**: Monitoring: costream pipeline failures log with guest/host ids;
+  rate-limit rejections reply `rate_limited` so the guest UI can back off.
+
+## References
+
+- **REF-001**: `.github/copilot-instructions.md` — "Co-streamer guest
+  captions" architecture section.
+- **REF-002**: `docs/costream-captions-user-guide.md` — user-facing guide.
+- **REF-003**: Related precedent: `caption_source_token` OBS overlay
+  (`CaptionSourceLive`) and admin local-extension-testing token minting.

--- a/docs/costream-captions-user-guide.md
+++ b/docs/costream-captions-user-guide.md
@@ -1,0 +1,129 @@
+# Captioning Your Co-Streamers: Guest Captions
+
+> **Draft** — for the site's help section. Screenshots and final link URLs to
+> be added before publishing.
+
+Streaming with a friend, a podcast guest, or a whole squad? Co-stream captions
+let the people streaming *with* you have their speech captioned too — shown to
+your viewers right alongside your own captions, labeled with their name, like:
+
+```
+Did you see that boss fight?
+Alice: I can't believe we actually beat it.
+```
+
+Your guests don't need a Stream Closed Captioner account, and you stay in
+control the whole time: you can mute or remove any guest instantly, and
+nothing they say reaches your viewers unless *you* are live and captioning.
+
+## What you'll need
+
+- **You (the host):** your normal Stream Closed Captioner setup — nothing new.
+- **Your guests:** Google Chrome, Microsoft Edge, or Safari. Guest captions
+  use the browser's built-in speech recognition, and other browsers don't
+  support it yet. That's the only requirement — no account, no install.
+- **Your viewers:** the current version of the Twitch extension. Viewers on
+  older versions simply won't see guest captions (your own captions are
+  unaffected).
+
+## Inviting a guest
+
+1. Open **Co-stream Captions** from your dashboard's side menu.
+2. Type your guest's name — this is the label viewers will see in front of
+   their captions, so pick something readable like `Alice`, not
+   `xX_alice_Xx_backup2`. You choose the name, not the guest.
+3. Click **Create invite link**, then **Copy**, and send the link to your
+   guest however you like (Discord DM, etc.).
+4. That's it. You can have up to **4 guest links** at a time.
+
+**Treat each link like a key to your stream's captions.** Anyone who has it
+can put words on your stream while you're live. Send it privately, and if a
+link ever leaks — or a guest turns out to be a gremlin — click
+**Kick & revoke** and that link is dead everywhere, immediately and
+permanently. Recurring co-streamer? Their link keeps working stream after
+stream until you revoke it, so you only have to send it once.
+
+## What your guest does
+
+Your guest opens the link and lands on a simple captioning page:
+
+1. Pick their **spoken language** (it starts on yours).
+2. Click **Start Captions** and allow microphone access when the browser asks.
+3. Talk. They'll see their own live captions on the page, exactly as your
+   viewers see them — including any words your filters cleaned up.
+
+The page also shows them two status badges worth knowing about:
+
+- **Connected / Connection problem** — their link to the caption service.
+- **Streamer is captioning / Streamer offline** — guest captions only flow
+  while *you* are actively captioning from your dashboard. If you stop, their
+  captions pause automatically; when you start again, they resume. A guest
+  can never broadcast to your audience while you're away.
+
+If they see a yellow browser warning instead of a Start button, they're not
+in Chrome, Edge, or Safari — have them reopen the link in one of those.
+
+## Staying in control while live
+
+The **Co-stream Captions** page doubles as your live control room. For each
+guest you can see whether they're connected and watch their captions in real
+time as they speak. Two buttons sit next to every guest:
+
+- **Mute** — their captions stop reaching viewers instantly, but they stay
+  connected and can be unmuted just as fast. Good for "hold on, someone's
+  eating chips into the mic."
+- **Kick & revoke** — disconnects them *and* permanently kills their link.
+  For when mute isn't enough.
+
+There's also a master switch at the top of the page — **Guest captions
+ON/OFF** — that silences *all* guest captions at once, no matter what, while
+leaving your own captions untouched. Think of it as the big red button.
+
+One more layer you already have: your **blocklist and profanity filter apply
+to everything your guests say**, using your settings. It's your stream —
+your rules run on their words too.
+
+## What your viewers see and control
+
+Guest captions appear in the extension interleaved with yours, each line
+prefixed with the guest's name. Viewers get their own controls in the
+extension's settings menu (the gear):
+
+- **Co-Streamer Captions** — show or hide guest captions entirely. It's on by
+  default, and the choice is remembered between visits.
+- Watching your captions **translated** into another language? Guest captions
+  aren't translated (they show in the guest's original language), so
+  translated viewers get an extra choice: see guests' original text mixed in,
+  or hide guests while translated.
+
+## Guest captions on your OBS overlay
+
+If you use the [caption overlay](caption-overlay-user-guide.md) as a browser
+source, guest captions appear there too, name-prefixed, with your configured
+caption delay applied — no changes needed on your end.
+
+## FAQ & troubleshooting
+
+**My guest talks but nothing shows up for viewers.**
+Check, in order: Are *you* captioning right now? (Guests pause when you're
+not.) Is the master **Guest captions** switch ON? Is that guest muted? Is the
+viewer on the latest extension version?
+
+**Can guests use translations or pirate mode?**
+No — guest captions are kept deliberately lightweight so several people can
+caption at once without slowing anything down. Filters yes, extras no.
+
+**Do guest captions get saved to my transcripts?**
+No. Only your own captions are stored.
+
+**My guest's captions are low quality.**
+Speech recognition quality depends on their browser and mic. Chrome generally
+does best; a headset mic beats a laptop mic; and picking the right spoken
+language on the guest page matters more than people expect.
+
+**How many guests can talk at once?**
+Up to 4 active guest links, all of whom can caption simultaneously.
+
+**I don't see the Co-stream Captions page.**
+The feature is being rolled out gradually — if the page says it isn't enabled
+for your account yet, hang tight.

--- a/lib/stream_closed_captioner_phoenix/captions_pipeline.ex
+++ b/lib/stream_closed_captioner_phoenix/captions_pipeline.ex
@@ -12,7 +12,7 @@ defmodule StreamClosedCaptionerPhoenix.CaptionsPipeline do
   @type message_map :: %{optional(String.t()) => term()}
 
   @spec pipeline_to(
-          :twitch | :zoom | :default,
+          :twitch | :zoom | :default | :costream,
           StreamClosedCaptionerPhoenix.Accounts.User.t(),
           message_map()
         ) ::
@@ -25,6 +25,22 @@ defmodule StreamClosedCaptionerPhoenix.CaptionsPipeline do
         CaptionsPayload.new(message)
         |> apply_censoring(stream_settings)
         |> apply_pirate_mode(stream_settings)
+
+      {:ok, payload}
+    else
+      {:error, _} -> {:error, "Stream settings not found"}
+    end
+  end
+
+  # Guest (co-streamer) text: the HOST owns what appears on their stream, so
+  # the host's censoring settings apply. No pirate mode and no translations —
+  # the guest path must stay cheap enough to fan out per concurrent speaker.
+  @trace :pipeline_to
+  def pipeline_to(:costream, %User{} = host, message) do
+    with {:ok, stream_settings} <- Settings.get_stream_settings_by_user_id(host.id) do
+      payload =
+        CaptionsPayload.new(message)
+        |> apply_censoring(stream_settings)
 
       {:ok, payload}
     else

--- a/lib/stream_closed_captioner_phoenix/captions_pipeline.ex
+++ b/lib/stream_closed_captioner_phoenix/captions_pipeline.ex
@@ -38,11 +38,7 @@ defmodule StreamClosedCaptionerPhoenix.CaptionsPipeline do
   @trace :pipeline_to
   def pipeline_to(:costream, %User{} = host, message) do
     with {:ok, stream_settings} <- Settings.get_stream_settings_by_user_id(host.id) do
-      payload =
-        CaptionsPayload.new(message)
-        |> apply_censoring(stream_settings)
-
-      {:ok, payload}
+      {:ok, censor_only(message, stream_settings)}
     else
       {:error, _} -> {:error, "Stream settings not found"}
     end
@@ -113,6 +109,17 @@ defmodule StreamClosedCaptionerPhoenix.CaptionsPipeline do
     else
       {:error, _} -> {:error, "Stream settings not found"}
     end
+  end
+
+  @doc """
+  Censoring-only pass over a caption message, for callers that already hold
+  the stream settings (the guest publish hot path checks the costream kill
+  switch and censors from a single settings fetch).
+  """
+  @spec censor_only(message_map(), StreamSettings.t()) :: CaptionsPayload.t()
+  def censor_only(message, %StreamSettings{} = stream_settings) do
+    CaptionsPayload.new(message)
+    |> apply_censoring(stream_settings)
   end
 
   defp apply_censoring(payload, %StreamSettings{} = stream_settings) do

--- a/lib/stream_closed_captioner_phoenix/costream.ex
+++ b/lib/stream_closed_captioner_phoenix/costream.ex
@@ -1,0 +1,133 @@
+defmodule StreamClosedCaptionerPhoenix.Costream do
+  @moduledoc """
+  Co-streamer guest captions.
+
+  A host creates per-guest shareable links; whoever opens a link gets a guest
+  dashboard that transcribes their speech in the browser and publishes it to
+  `CostreamChannel`. Guest captions are censored with the host's settings and
+  fanned out to the Twitch extension (`new_costream_caption` subscription) and
+  the OBS overlay — never translated or pirate-moded, keeping the guest path
+  cheap enough to run for several concurrent speakers.
+
+  The whole feature is gated by the `#{inspect(:costream_captions)}` feature
+  flag (per host) plus the `costream_enabled` kill switch on stream settings.
+  """
+  import Ecto.Query, warn: false
+
+  alias StreamClosedCaptionerPhoenix.Accounts.User
+  alias StreamClosedCaptionerPhoenix.Costream.Guest
+  alias StreamClosedCaptionerPhoenix.{Repo, Settings}
+
+  @feature_flag :costream_captions
+  @max_active_guests 4
+  @token_salt "costream guest"
+
+  def feature_flag, do: @feature_flag
+  def max_active_guests, do: @max_active_guests
+
+  @doc "Whether the costream feature is rolled out to this host at all."
+  def feature_enabled?(%User{} = user), do: FunWithFlags.enabled?(@feature_flag, for: user)
+
+  @doc """
+  Whether guests may currently publish for this host: feature flag AND the
+  host's `costream_enabled` kill switch. Checked on every guest publish so
+  flipping the switch silences guests instantly.
+  """
+  def publishing_enabled?(%User{} = host) do
+    feature_enabled?(host) and
+      case Settings.get_stream_settings_by_user_id(host.id) do
+        {:ok, stream_settings} -> stream_settings.costream_enabled
+        {:error, _} -> false
+      end
+  end
+
+  @doc "Active (unrevoked) guests for a host, oldest first."
+  def list_active_guests(%User{id: user_id}) do
+    Guest
+    |> where([g], g.user_id == ^user_id and is_nil(g.revoked_at))
+    |> order_by([g], asc: g.id)
+    |> Repo.all()
+  end
+
+  @doc "Fetches a guest scoped to its host, so hosts can only manage their own."
+  def get_guest_for(%User{id: user_id}, id) do
+    case Repo.get_by(Guest, id: id, user_id: user_id) do
+      nil -> {:error, :not_found}
+      guest -> {:ok, guest}
+    end
+  end
+
+  @doc "Fetches an unrevoked guest with the host user preloaded."
+  def get_active_guest(id) do
+    case Repo.get(Guest, id) do
+      %Guest{revoked_at: nil} = guest -> {:ok, Repo.preload(guest, :user)}
+      _ -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Creates a guest link for a host, capped at #{@max_active_guests} active
+  guests so extension layout and fan-out stay bounded.
+  """
+  def create_guest(%User{} = host, attrs) do
+    if length(list_active_guests(host)) >= @max_active_guests do
+      {:error, :guest_limit_reached}
+    else
+      %Guest{user_id: host.id}
+      |> Guest.changeset(attrs)
+      |> Repo.insert()
+    end
+  end
+
+  @doc "Permanently disables a guest link. Existing tokens stop verifying."
+  def revoke_guest(%Guest{} = guest) do
+    guest
+    |> Ecto.Changeset.change(revoked_at: DateTime.truncate(DateTime.utc_now(), :second))
+    |> Repo.update()
+  end
+
+  def set_guest_muted(%Guest{} = guest, muted) when is_boolean(muted) do
+    guest
+    |> Ecto.Changeset.change(muted: muted)
+    |> Repo.update()
+  end
+
+  @doc """
+  Signs a standing link token for a guest. The token never expires on its
+  own — revocation is the `revoked_at` flag, checked on every verify.
+  """
+  def guest_token(%Guest{id: id}) do
+    Phoenix.Token.sign(StreamClosedCaptionerPhoenixWeb.Endpoint, @token_salt, id)
+  end
+
+  @doc """
+  Verifies a guest link token: signature, guest not revoked, and the host's
+  feature flag still on. Returns the guest with the host user preloaded.
+  """
+  def verify_guest_token(token) when is_binary(token) do
+    with {:ok, guest_id} <-
+           Phoenix.Token.verify(StreamClosedCaptionerPhoenixWeb.Endpoint, @token_salt, token,
+             max_age: :infinity
+           ),
+         {:ok, %Guest{} = guest} <- get_active_guest(guest_id) do
+      if feature_enabled?(guest.user) do
+        {:ok, guest}
+      else
+        {:error, :feature_disabled}
+      end
+    else
+      _ -> {:error, :invalid}
+    end
+  end
+
+  def verify_guest_token(_token), do: {:error, :invalid}
+
+  @doc "PubSub topic the host dashboard subscribes to for live guest activity."
+  def monitor_topic(host_user_id), do: "costream_monitor:#{host_user_id}"
+
+  @doc "Phoenix channel topic guests and the host monitor join."
+  def channel_topic(host_user_id), do: "costream:#{host_user_id}"
+
+  @doc "UserTracker presence topic listing currently connected guests."
+  def presence_topic(host_user_id), do: "costream_guests:#{host_user_id}"
+end

--- a/lib/stream_closed_captioner_phoenix/costream.ex
+++ b/lib/stream_closed_captioner_phoenix/costream.ex
@@ -69,8 +69,13 @@ defmodule StreamClosedCaptionerPhoenix.Costream do
   Creates a guest link for a host, capped at #{@max_active_guests} active
   guests so extension layout and fan-out stay bounded.
   """
-  def create_guest(%User{} = host, attrs) do
-    if length(list_active_guests(host)) >= @max_active_guests do
+  def create_guest(%User{id: user_id} = host, attrs) do
+    active_count =
+      Guest
+      |> where([g], g.user_id == ^user_id and is_nil(g.revoked_at))
+      |> Repo.aggregate(:count)
+
+    if active_count >= @max_active_guests do
       {:error, :guest_limit_reached}
     else
       %Guest{user_id: host.id}

--- a/lib/stream_closed_captioner_phoenix/costream/guest.ex
+++ b/lib/stream_closed_captioner_phoenix/costream/guest.ex
@@ -1,0 +1,30 @@
+defmodule StreamClosedCaptionerPhoenix.Costream.Guest do
+  @moduledoc """
+  A co-streamer guest invited by a host via a per-guest shareable link.
+
+  The link token only carries the guest id — authorization state (revocation,
+  mute, display name) lives on this record so the host's actions take effect
+  immediately, without rotating tokens.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "costream_guests" do
+    field(:name, :string)
+    field(:muted, :boolean, default: false)
+    field(:revoked_at, :utc_datetime)
+    belongs_to(:user, StreamClosedCaptionerPhoenix.Accounts.User)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(guest, attrs) do
+    guest
+    |> cast(attrs, [:name])
+    |> update_change(:name, &String.trim/1)
+    |> validate_required([:name])
+    |> validate_length(:name, min: 1, max: 50)
+    |> foreign_key_constraint(:user_id)
+  end
+end

--- a/lib/stream_closed_captioner_phoenix/costream/guest.ex
+++ b/lib/stream_closed_captioner_phoenix/costream/guest.ex
@@ -22,7 +22,7 @@ defmodule StreamClosedCaptionerPhoenix.Costream.Guest do
   def changeset(guest, attrs) do
     guest
     |> cast(attrs, [:name])
-    |> update_change(:name, &String.trim/1)
+    |> update_change(:name, &if(is_binary(&1), do: String.trim(&1), else: &1))
     |> validate_required([:name])
     |> validate_length(:name, min: 1, max: 50)
     |> foreign_key_constraint(:user_id)

--- a/lib/stream_closed_captioner_phoenix/factory.ex
+++ b/lib/stream_closed_captioner_phoenix/factory.ex
@@ -92,6 +92,14 @@ defmodule StreamClosedCaptionerPhoenix.Factory do
     }
   end
 
+  def costream_guest_factory do
+    %StreamClosedCaptionerPhoenix.Costream.Guest{
+      name: sequence(:guest_name, &"Guest #{&1}"),
+      muted: false,
+      user: build(:bare_user)
+    }
+  end
+
   def translate_language_factory do
     %StreamClosedCaptionerPhoenix.Settings.TranslateLanguage{
       language: "en"

--- a/lib/stream_closed_captioner_phoenix/settings/stream_settings.ex
+++ b/lib/stream_closed_captioner_phoenix/settings/stream_settings.ex
@@ -16,6 +16,7 @@ defmodule StreamClosedCaptionerPhoenix.Settings.StreamSettings do
     field(:text_uppercase, :boolean, default: false)
     field(:turn_on_reminder, :boolean, default: false)
     field(:auto_off_captions, :boolean, default: false)
+    field(:costream_enabled, :boolean, default: true)
     field(:caption_source_token, :string)
     belongs_to(:user, StreamClosedCaptionerPhoenix.Accounts.User)
 
@@ -30,6 +31,7 @@ defmodule StreamClosedCaptionerPhoenix.Settings.StreamSettings do
       :blocklist,
       :caption_delay,
       :cc_box_size,
+      :costream_enabled,
       :filter_profanity,
       :hide_text_on_load,
       :language,
@@ -88,6 +90,7 @@ defmodule StreamClosedCaptionerPhoenix.Settings.StreamSettings do
       :blocklist,
       :caption_delay,
       :cc_box_size,
+      :costream_enabled,
       :filter_profanity,
       :hide_text_on_load,
       :language,

--- a/lib/stream_closed_captioner_phoenix_web/channels/captions_channel.ex
+++ b/lib/stream_closed_captioner_phoenix_web/channels/captions_channel.ex
@@ -109,9 +109,13 @@ defmodule StreamClosedCaptionerPhoenixWeb.CaptionsChannel do
 
   defp track_user(nil), do: nil
 
-  # Add authorization logic here as required.
+  # Only a user-token socket may join; costream guest sockets (which carry
+  # :costream_guest instead of :current_user) are rejected here.
   defp authorized?(socket, user_id) do
-    user_id == to_string(socket.assigns.current_user.id)
+    case socket.assigns[:current_user] do
+      %{id: id} -> user_id == to_string(id)
+      _ -> false
+    end
   end
 
   defp time_to_complete(nil), do: 0

--- a/lib/stream_closed_captioner_phoenix_web/channels/costream_channel.ex
+++ b/lib/stream_closed_captioner_phoenix_web/channels/costream_channel.ex
@@ -70,7 +70,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.CostreamChannel do
       not UserTracker.channel_active?(host.uid) ->
         {:reply, {:error, %{reason: "host_offline"}}, socket}
 
-      not Costream.publishing_enabled?(host) ->
+      not Costream.feature_enabled?(host) ->
         {:reply, {:error, %{reason: "disabled"}}, socket}
 
       true ->
@@ -155,8 +155,23 @@ defmodule StreamClosedCaptionerPhoenixWeb.CostreamChannel do
     end
   end
 
+  # One settings fetch per publish serves both the kill-switch check and the
+  # censoring pass — this is the hot path (up to 15/sec × 4 guests).
   defp publish_captions(guest, host, payload, socket) do
-    case safe_pipeline(host, payload) do
+    case StreamClosedCaptionerPhoenix.Settings.get_stream_settings_by_user_id(host.id) do
+      {:ok, %{costream_enabled: false}} ->
+        {:reply, {:error, %{reason: "disabled"}}, socket}
+
+      {:ok, stream_settings} ->
+        censor_and_fan_out(guest, host, stream_settings, payload, socket)
+
+      {:error, _} ->
+        {:reply, {:error, %{reason: "pipeline_failed"}}, socket}
+    end
+  end
+
+  defp censor_and_fan_out(guest, host, stream_settings, payload, socket) do
+    case safe_censor(host, stream_settings, payload) do
       {:ok, censored} ->
         caption = %{
           guest_id: guest.id,
@@ -188,8 +203,8 @@ defmodule StreamClosedCaptionerPhoenixWeb.CostreamChannel do
     end
   end
 
-  defp safe_pipeline(host, payload) do
-    StreamClosedCaptionerPhoenix.CaptionsPipeline.pipeline_to(:costream, host, payload)
+  defp safe_censor(host, stream_settings, payload) do
+    {:ok, StreamClosedCaptionerPhoenix.CaptionsPipeline.censor_only(payload, stream_settings)}
   rescue
     e ->
       Logger.error(

--- a/lib/stream_closed_captioner_phoenix_web/channels/costream_channel.ex
+++ b/lib/stream_closed_captioner_phoenix_web/channels/costream_channel.ex
@@ -1,0 +1,228 @@
+defmodule StreamClosedCaptionerPhoenixWeb.CostreamChannel do
+  @moduledoc """
+  Channel for co-streamer guest captions. Topic: `costream:HOST_USER_ID`.
+
+  Two roles may join:
+
+    * **guest** — a socket authenticated by a costream link token whose guest
+      record belongs to the host. May publish captions.
+    * **host** — the host's own user socket, read-only. Mute/kick originate
+      from the host UI as `Endpoint.broadcast/3` control events
+      (`guest_muted` / `guest_kicked`), intercepted below so they reach the
+      matching guest's channel process on any node.
+
+  Guest publishes are rate limited per guest, censored with the host's
+  settings (`CaptionsPipeline` `:costream` path — no translations, no pirate
+  mode), and gated on the host actively captioning plus the costream kill
+  switch. Successful publishes fan out to the Twitch extension
+  (`new_costream_caption`), the OBS overlay PubSub topic, and the host's
+  monitor topic.
+  """
+  use StreamClosedCaptionerPhoenixWeb, :channel
+  require Logger
+
+  alias StreamClosedCaptionerPhoenix.Costream
+  alias StreamClosedCaptionerPhoenix.RateLimit
+  alias StreamClosedCaptionerPhoenixWeb.UserTracker
+
+  # Generous enough for a speech recognizer emitting interim results several
+  # times a second, tight enough that a scripted link-holder can't flood
+  # every viewer's extension.
+  @rate_limit_scale_ms 1_000
+  @rate_limit_max_hits 15
+
+  # How often guests are told whether the host is actively captioning.
+  @host_status_interval_ms 30_000
+
+  intercept(["guest_muted", "guest_kicked"])
+
+  @impl true
+  def join("costream:" <> host_id, _payload, socket) do
+    case role(socket, host_id) do
+      {:guest, guest} ->
+        send(self(), :after_join)
+
+        socket =
+          socket
+          |> assign(:costream_guest, guest)
+          |> assign(:host, guest.user)
+          |> assign(:muted, guest.muted)
+
+        {:ok, %{name: guest.name, muted: guest.muted}, socket}
+
+      :host ->
+        {:ok, socket}
+
+      :unauthorized ->
+        {:error, %{reason: "unauthorized"}}
+    end
+  end
+
+  @impl true
+  def handle_in("publish", payload, %{assigns: %{costream_guest: guest, host: host}} = socket) do
+    cond do
+      socket.assigns.muted ->
+        {:reply, {:error, %{reason: "muted"}}, socket}
+
+      rate_limited?(guest) ->
+        {:reply, {:error, %{reason: "rate_limited"}}, socket}
+
+      not UserTracker.channel_active?(host.uid) ->
+        {:reply, {:error, %{reason: "host_offline"}}, socket}
+
+      not Costream.publishing_enabled?(host) ->
+        {:reply, {:error, %{reason: "disabled"}}, socket}
+
+      true ->
+        publish_captions(guest, host, payload, socket)
+    end
+  end
+
+  def handle_in("publish", _payload, socket) do
+    {:reply, {:error, %{reason: "unauthorized"}}, socket}
+  end
+
+  @impl true
+  def handle_out("guest_muted", %{guest_id: guest_id, muted: muted}, socket) do
+    case socket.assigns[:costream_guest] do
+      %{id: ^guest_id} ->
+        push(socket, "muted", %{muted: muted})
+        {:noreply, assign(socket, :muted, muted)}
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_out("guest_kicked", %{guest_id: guest_id}, socket) do
+    case socket.assigns[:costream_guest] do
+      %{id: ^guest_id} ->
+        push(socket, "kicked", %{})
+        {:stop, :normal, socket}
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_info(:after_join, socket) do
+    guest = socket.assigns.costream_guest
+    host = socket.assigns.host
+
+    UserTracker.track(self(), Costream.presence_topic(host.id), to_string(guest.id), %{
+      name: guest.name
+    })
+
+    broadcast_monitor(host.id, {:costream_guest_joined, %{guest_id: guest.id, name: guest.name}})
+    push_host_status(socket)
+
+    {:noreply, socket}
+  end
+
+  def handle_info(:host_status, socket) do
+    push_host_status(socket)
+    {:noreply, socket}
+  end
+
+  @impl true
+  def terminate(_reason, socket) do
+    with %{costream_guest: guest, host: host} <- socket.assigns do
+      broadcast_monitor(host.id, {:costream_guest_left, %{guest_id: guest.id}})
+    end
+
+    :ok
+  end
+
+  # Guest authorization re-reads the DB record on join so a revoked guest
+  # can't rejoin on a socket that authenticated before the revocation.
+  defp role(socket, host_id) do
+    cond do
+      guest = socket.assigns[:costream_guest] ->
+        case Costream.get_active_guest(guest.id) do
+          {:ok, %{user_id: user_id} = fresh} ->
+            if to_string(user_id) == host_id, do: {:guest, fresh}, else: :unauthorized
+
+          {:error, _} ->
+            :unauthorized
+        end
+
+      user = socket.assigns[:current_user] ->
+        if to_string(user.id) == host_id, do: :host, else: :unauthorized
+
+      true ->
+        :unauthorized
+    end
+  end
+
+  defp publish_captions(guest, host, payload, socket) do
+    case safe_pipeline(host, payload) do
+      {:ok, censored} ->
+        caption = %{
+          guest_id: guest.id,
+          name: guest.name,
+          interim: censored.interim,
+          final: censored.final
+        }
+
+        Absinthe.Subscription.publish(StreamClosedCaptionerPhoenixWeb.Endpoint, caption,
+          new_costream_caption: host.uid
+        )
+
+        Phoenix.PubSub.broadcast(
+          StreamClosedCaptionerPhoenix.PubSub,
+          "caption_source:#{host.id}",
+          {:costream_caption_payload, caption}
+        )
+
+        broadcast_monitor(host.id, {:costream_caption, caption})
+
+        {:reply, {:ok, caption}, socket}
+
+      {:error, reason} ->
+        Logger.error(
+          "Costream pipeline failed for guest #{guest.id} (host #{host.id}): #{inspect(reason)}"
+        )
+
+        {:reply, {:error, %{reason: "pipeline_failed"}}, socket}
+    end
+  end
+
+  defp safe_pipeline(host, payload) do
+    StreamClosedCaptionerPhoenix.CaptionsPipeline.pipeline_to(:costream, host, payload)
+  rescue
+    e ->
+      Logger.error(
+        "Costream pipeline raised for host #{host.id}: #{Exception.format(:error, e, __STACKTRACE__)}"
+      )
+
+      {:error, :exception}
+  end
+
+  defp rate_limited?(guest) do
+    case RateLimit.hit(
+           "costream_publish:#{guest.id}",
+           @rate_limit_scale_ms,
+           @rate_limit_max_hits
+         ) do
+      {:allow, _count} -> false
+      {:deny, _timeout} -> true
+    end
+  end
+
+  defp push_host_status(socket) do
+    push(socket, "host_status", %{
+      active: UserTracker.channel_active?(socket.assigns.host.uid)
+    })
+
+    Process.send_after(self(), :host_status, @host_status_interval_ms)
+  end
+
+  defp broadcast_monitor(host_user_id, message) do
+    Phoenix.PubSub.broadcast(
+      StreamClosedCaptionerPhoenix.PubSub,
+      Costream.monitor_topic(host_user_id),
+      message
+    )
+  end
+end

--- a/lib/stream_closed_captioner_phoenix_web/channels/user_socket.ex
+++ b/lib/stream_closed_captioner_phoenix_web/channels/user_socket.ex
@@ -8,6 +8,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.UserSocket do
   # channel "room:*", StreamClosedCaptionerPhoenixWeb.RoomChannel
 
   channel("captions:*", StreamClosedCaptionerPhoenixWeb.CaptionsChannel)
+  channel("costream:*", StreamClosedCaptionerPhoenixWeb.CostreamChannel)
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
@@ -26,6 +27,20 @@ defmodule StreamClosedCaptionerPhoenixWeb.UserSocket do
       {:ok, user_id} ->
         current_user = Accounts.get_user!(user_id)
         {:ok, assign(socket, :current_user, current_user)}
+
+      {:error, _} ->
+        :error
+    end
+  end
+
+  # Co-streamer guest socket: authenticated purely by the signed guest link
+  # token (no user account). Grants access to the host's costream channel
+  # only — CaptionsChannel requires :current_user, which is never assigned
+  # here.
+  def connect(%{"costreamToken" => token}, socket, _connect_info) do
+    case StreamClosedCaptionerPhoenix.Costream.verify_guest_token(token) do
+      {:ok, guest} ->
+        {:ok, assign(socket, :costream_guest, guest)}
 
       {:error, _} ->
         :error

--- a/lib/stream_closed_captioner_phoenix_web/components/layouts/logged_in.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/components/layouts/logged_in.html.heex
@@ -154,6 +154,20 @@
             </svg>
             <span>Caption Settings</span>
           </.link>
+          <.link
+            navigate={~p"/users/costream"}
+            class="flex items-center px-4 py-3 transition cursor-pointer group hover:bg-gray-800 hover:text-gray-200"
+          >
+            <svg
+              class="shrink-0 w-5 h-5 mr-2 text-gray-400 transition group-hover:text-gray-300"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
+            </svg>
+            <span>Co-stream Captions</span>
+          </.link>
         </nav>
       </nav>
       <div class="ml-0 transition md:ml-60">

--- a/lib/stream_closed_captioner_phoenix_web/controllers/costream_guest/invalid.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/costream_guest/invalid.html.heex
@@ -1,0 +1,7 @@
+<div class="max-w-xl mx-auto px-4 py-16 text-center">
+  <h1 class="text-2xl font-bold mb-4 dark:text-white">This co-stream link isn't valid</h1>
+  <p class="text-gray-600 dark:text-gray-300">
+    The link may have been revoked by the streamer, or it was copied
+    incorrectly. Ask the streamer to send you a new invite link.
+  </p>
+</div>

--- a/lib/stream_closed_captioner_phoenix_web/controllers/costream_guest/show.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/costream_guest/show.html.heex
@@ -1,0 +1,96 @@
+<div
+  class="max-w-3xl mx-auto px-4 py-8"
+  data-controller="costream"
+  data-costream-token-value={@token}
+  data-costream-host-id-value={@host.id}
+  data-costream-language-value={@default_language}
+>
+  <div class="mb-6">
+    <h1 class="text-2xl font-bold dark:text-white">
+      You're captioning as {@guest.name}
+    </h1>
+    <p class="text-gray-600 dark:text-gray-300">
+      Your speech is transcribed in your browser and shown alongside {@host.username}'s captions on their stream.
+    </p>
+  </div>
+
+  <div
+    data-costream-target="warning"
+    class="hidden mb-4 rounded-md bg-yellow-100 border border-yellow-300 px-4 py-3 text-yellow-900"
+  >
+    Speech to text is only supported in Google Chrome, Microsoft Edge, and Safari.
+    Please open this link in one of those browsers.
+  </div>
+
+  <div
+    data-costream-target="kicked"
+    class="hidden mb-4 rounded-md bg-red-100 border border-red-300 px-4 py-3 text-red-900"
+  >
+    The streamer removed you from this co-stream. This link no longer works.
+  </div>
+
+  <div class="mb-4 flex flex-wrap items-center gap-2 text-sm">
+    <span
+      data-costream-target="connectionBadge"
+      class="rounded-full px-3 py-1 bg-gray-200 text-gray-700"
+    >
+      Connecting…
+    </span>
+    <span
+      data-costream-target="hostBadge"
+      class="rounded-full px-3 py-1 bg-gray-200 text-gray-700"
+    >
+      Checking if {@host.username} is live…
+    </span>
+    <span
+      data-costream-target="mutedBadge"
+      class="hidden rounded-full px-3 py-1 bg-red-200 text-red-800"
+    >
+      Muted by the streamer
+    </span>
+  </div>
+
+  <div class="mb-6 flex flex-wrap items-end gap-4">
+    <label class="block">
+      <span class="block text-sm font-medium mb-1 dark:text-gray-200">Your spoken language</span>
+      <select
+        data-costream-target="language"
+        data-action="change->costream#languageChanged"
+        class="rounded border-gray-300 dark:bg-gray-800 dark:text-white"
+      >
+        <%= for {language, regions} <- Enum.sort(@spoken_languages) do %>
+          <optgroup label={language}>
+            <option
+              :for={{region, code} <- regions}
+              value={code}
+              selected={code == @default_language}
+            >
+              {language} ({region})
+            </option>
+          </optgroup>
+        <% end %>
+      </select>
+    </label>
+
+    <button
+      type="button"
+      data-costream-target="start"
+      data-action="click->costream#toggleCaptions"
+      disabled
+      class="btn-primary rounded bg-purple-700 px-6 py-2 font-semibold text-white hover:bg-purple-800 disabled:opacity-50"
+    >
+      Start Captions
+    </button>
+  </div>
+
+  <div class="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 min-h-[10rem]">
+    <h2 class="text-sm uppercase tracking-wide text-gray-500 mb-2">Your captions</h2>
+    <p data-costream-target="finalOutput" class="dark:text-white"></p>
+    <p data-costream-target="interimOutput" class="text-gray-500 italic"></p>
+  </div>
+
+  <p class="mt-4 text-sm text-gray-500">
+    Captions only reach viewers while the streamer is actively captioning.
+    Your words are filtered with the streamer's content settings.
+  </p>
+</div>

--- a/lib/stream_closed_captioner_phoenix_web/controllers/costream_guest_controller.ex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/costream_guest_controller.ex
@@ -1,0 +1,37 @@
+defmodule StreamClosedCaptionerPhoenixWeb.CostreamGuestController do
+  @moduledoc """
+  Public guest dashboard for co-streamer captions, reached via a per-guest
+  shareable link. No account required: the signed token in the URL is the
+  entire credential, verified against the guest record (revocation, host
+  feature flag) on every load.
+  """
+  use StreamClosedCaptionerPhoenixWeb, :controller
+
+  alias StreamClosedCaptionerPhoenix.{Costream, Settings}
+
+  def show(conn, %{"token" => token}) do
+    case Costream.verify_guest_token(token) do
+      {:ok, guest} ->
+        render(conn, "show.html",
+          guest: guest,
+          host: guest.user,
+          token: token,
+          default_language: host_language(guest.user),
+          spoken_languages: Settings.spoken_languages(),
+          page_title: "Co-stream captions"
+        )
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:not_found)
+        |> render("invalid.html", page_title: "Co-stream captions")
+    end
+  end
+
+  defp host_language(host) do
+    case Settings.get_stream_settings_by_user_id(host.id) do
+      {:ok, stream_settings} -> stream_settings.language
+      {:error, _} -> "en-US"
+    end
+  end
+end

--- a/lib/stream_closed_captioner_phoenix_web/controllers/costream_guest_html.ex
+++ b/lib/stream_closed_captioner_phoenix_web/controllers/costream_guest_html.ex
@@ -1,0 +1,4 @@
+defmodule StreamClosedCaptionerPhoenixWeb.CostreamGuestHTML do
+  use StreamClosedCaptionerPhoenixWeb, :html
+  embed_templates("costream_guest/*")
+end

--- a/lib/stream_closed_captioner_phoenix_web/live/admin/local_extension_testing_live.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/admin/local_extension_testing_live.ex
@@ -93,7 +93,9 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.LocalExtensionTestingLive do
       >
         <div>
           <.input field={@form[:local_base]} type="text" label="Local extension URL" />
-          <p class="mt-1 text-xs text-gray-500">Where your <code>yarn start</code> dev server is served.</p>
+          <p class="mt-1 text-xs text-gray-500">
+            Where your <code>yarn start</code> dev server is served.
+          </p>
         </div>
         <div>
           <.input
@@ -102,7 +104,9 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.LocalExtensionTestingLive do
             label="Manual channel id (optional)"
             placeholder="Twitch channel/user id"
           />
-          <p class="mt-1 text-xs text-gray-500">Target a specific channel even if it isn't listed below.</p>
+          <p class="mt-1 text-xs text-gray-500">
+            Target a specific channel even if it isn't listed below.
+          </p>
         </div>
       </.form>
 
@@ -127,7 +131,11 @@ defmodule StreamClosedCaptionerPhoenixWeb.Admin.LocalExtensionTestingLive do
           No channels are currently captioning. Click "Refresh" once a broadcaster is live.
         </p>
 
-        <ul :if={@active_channels != []} role="list" class="divide-y divide-gray-200 border border-gray-200 rounded-md">
+        <ul
+          :if={@active_channels != []}
+          role="list"
+          class="divide-y divide-gray-200 border border-gray-200 rounded-md"
+        >
           <li
             :for={channel <- @active_channels}
             id={"channel-#{channel.uid}"}

--- a/lib/stream_closed_captioner_phoenix_web/live/caption_source_live/show.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/caption_source_live/show.ex
@@ -323,6 +323,32 @@ defmodule StreamClosedCaptionerPhoenixWeb.CaptionSourceLive.Show do
     {:noreply, apply_caption(socket, payload)}
   end
 
+  # Co-streamer guest captions: only finals, name-prefixed. Guest interim
+  # frames are dropped here — the overlay has a single interim line and
+  # interleaving several concurrent speakers into it would just flicker.
+  def handle_info({:costream_caption_payload, %{final: final, name: name}}, socket)
+      when is_binary(final) and final != "" do
+    delay = socket.assigns.stream_settings.caption_delay || 0
+    entry = "#{name}: #{final}"
+
+    if delay > 0 do
+      Process.send_after(self(), {:apply_costream_caption, entry}, delay * 1000)
+      {:noreply, socket}
+    else
+      {:noreply, apply_costream_caption(socket, entry)}
+    end
+  end
+
+  def handle_info({:costream_caption_payload, _payload}, socket), do: {:noreply, socket}
+
+  def handle_info({:apply_costream_caption, entry}, socket) do
+    {:noreply, apply_costream_caption(socket, entry)}
+  end
+
+  defp apply_costream_caption(socket, entry) do
+    assign(socket, :final_text, append_final(socket.assigns.final_text, entry))
+  end
+
   defp apply_caption(socket, payload) do
     final = Map.get(payload, :final) || ""
     interim = Map.get(payload, :interim) || ""

--- a/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.ex
@@ -1,0 +1,149 @@
+defmodule StreamClosedCaptionerPhoenixWeb.CostreamLive.Index do
+  @moduledoc """
+  Host dashboard for co-streamer captions: create/revoke per-guest links,
+  watch each connected guest's live caption text, mute/kick guests, and flip
+  the kill switch that silences all guest captions at once.
+
+  Live activity arrives over the costream monitor PubSub topic (published by
+  `CostreamChannel`); mute/kick are pushed back to guest channel processes
+  via `Endpoint.broadcast/3` control events.
+  """
+  use StreamClosedCaptionerPhoenixWeb, :live_view
+
+  import StreamClosedCaptionerPhoenixWeb.LiveHelpers
+
+  alias StreamClosedCaptionerPhoenix.{Costream, Repo, Settings}
+  alias StreamClosedCaptionerPhoenixWeb.UserTracker
+
+  @impl true
+  def mount(_params, session, socket) do
+    current_user =
+      session_current_user(session)
+      |> Repo.preload(:stream_settings)
+
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(
+        StreamClosedCaptionerPhoenix.PubSub,
+        Costream.monitor_topic(current_user.id)
+      )
+    end
+
+    connected_ids =
+      Costream.presence_topic(current_user.id)
+      |> UserTracker.list()
+      |> MapSet.new(fn {guest_id, _meta} -> guest_id end)
+
+    {:ok,
+     socket
+     |> assign(:current_user, current_user)
+     |> assign(:page_title, "Co-stream Captions")
+     |> assign(:feature_enabled, Costream.feature_enabled?(current_user))
+     |> assign(:costream_enabled, current_user.stream_settings.costream_enabled)
+     |> assign(:guests, Costream.list_active_guests(current_user))
+     |> assign(:connected_ids, connected_ids)
+     |> assign(:live_text, %{})
+     |> assign(:new_guest_name, "")}
+  end
+
+  @impl true
+  def handle_event("create_guest", %{"name" => name}, socket) do
+    case Costream.create_guest(socket.assigns.current_user, %{name: name}) do
+      {:ok, _guest} ->
+        {:noreply, refresh_guests(socket) |> assign(:new_guest_name, "")}
+
+      {:error, :guest_limit_reached} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "You can have at most #{Costream.max_active_guests()} active guests. Revoke one first."
+         )}
+
+      {:error, %Ecto.Changeset{}} ->
+        {:noreply, put_flash(socket, :error, "Guest name can't be blank.")}
+    end
+  end
+
+  def handle_event("toggle_mute", %{"id" => id}, socket) do
+    with {:ok, guest} <- Costream.get_guest_for(socket.assigns.current_user, id),
+         {:ok, updated} <- Costream.set_guest_muted(guest, !guest.muted) do
+      broadcast_control(socket, "guest_muted", %{guest_id: updated.id, muted: updated.muted})
+      {:noreply, refresh_guests(socket)}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("revoke", %{"id" => id}, socket) do
+    with {:ok, guest} <- Costream.get_guest_for(socket.assigns.current_user, id),
+         {:ok, revoked} <- Costream.revoke_guest(guest) do
+      broadcast_control(socket, "guest_kicked", %{guest_id: revoked.id})
+      {:noreply, refresh_guests(socket)}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("toggle_kill_switch", _params, socket) do
+    stream_settings = socket.assigns.current_user.stream_settings
+    enabled = !socket.assigns.costream_enabled
+
+    case Settings.update_stream_settings(stream_settings, %{costream_enabled: enabled}) do
+      {:ok, updated} ->
+        current_user = %{socket.assigns.current_user | stream_settings: updated}
+
+        {:noreply,
+         socket
+         |> assign(:current_user, current_user)
+         |> assign(:costream_enabled, updated.costream_enabled)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Could not update the setting.")}
+    end
+  end
+
+  @impl true
+  def handle_info({:costream_guest_joined, %{guest_id: guest_id}}, socket) do
+    {:noreply, update(socket, :connected_ids, &MapSet.put(&1, to_string(guest_id)))}
+  end
+
+  def handle_info({:costream_guest_left, %{guest_id: guest_id}}, socket) do
+    {:noreply, update(socket, :connected_ids, &MapSet.delete(&1, to_string(guest_id)))}
+  end
+
+  def handle_info({:costream_caption, caption}, socket) do
+    live_text =
+      Map.update(
+        socket.assigns.live_text,
+        caption.guest_id,
+        %{interim: caption.interim, final: caption.final},
+        fn current ->
+          %{
+            interim: caption.interim,
+            final: if(caption.final == "", do: current.final, else: caption.final)
+          }
+        end
+      )
+
+    {:noreply, assign(socket, :live_text, live_text)}
+  end
+
+  defp refresh_guests(socket) do
+    assign(socket, :guests, Costream.list_active_guests(socket.assigns.current_user))
+  end
+
+  defp broadcast_control(socket, event, payload) do
+    StreamClosedCaptionerPhoenixWeb.Endpoint.broadcast(
+      Costream.channel_topic(socket.assigns.current_user.id),
+      event,
+      payload
+    )
+  end
+
+  defp guest_url(guest) do
+    url(~p"/costream/#{Costream.guest_token(guest)}")
+  end
+
+  defp guest_connected?(connected_ids, guest),
+    do: MapSet.member?(connected_ids, to_string(guest.id))
+end

--- a/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.ex
+++ b/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.ex
@@ -84,6 +84,10 @@ defmodule StreamClosedCaptionerPhoenixWeb.CostreamLive.Index do
     end
   end
 
+  def handle_event("clear_flash", %{"key" => key}, socket) do
+    {:noreply, clear_flash(socket, key)}
+  end
+
   def handle_event("toggle_kill_switch", _params, socket) do
     stream_settings = socket.assigns.current_user.stream_settings
     enabled = !socket.assigns.costream_enabled

--- a/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.html.heex
@@ -139,3 +139,23 @@
     </ul>
   </div>
 </div>
+
+<div
+  :if={msg = Phoenix.Flash.get(@flash, :error)}
+  id="costream-toast-error"
+  class="toast toast--error"
+  data-key="error"
+  phx-hook="Toast"
+  phx-click="clear_flash"
+  phx-value-key="error"
+  role="alert"
+>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+    <path
+      d="M12 8v5M12 16h.01M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18Z"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+  {msg}
+</div>

--- a/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.html.heex
@@ -1,0 +1,141 @@
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <div class="mb-6 flex items-start justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-bold dark:text-white">Co-stream Captions</h1>
+      <p class="text-gray-600 dark:text-gray-300">
+        Invite guests with a personal link. Their speech is captioned in their
+        browser and shown to viewers alongside yours.
+      </p>
+    </div>
+    <button
+      :if={@feature_enabled}
+      type="button"
+      phx-click="toggle_kill_switch"
+      class={[
+        "shrink-0 rounded px-4 py-2 font-semibold text-white",
+        (@costream_enabled && "bg-green-600 hover:bg-green-700") ||
+          "bg-red-600 hover:bg-red-700"
+      ]}
+    >
+      {if @costream_enabled, do: "Guest captions ON", else: "Guest captions OFF"}
+    </button>
+  </div>
+
+  <div
+    :if={!@feature_enabled}
+    class="rounded-md bg-yellow-100 border border-yellow-300 px-4 py-3 text-yellow-900"
+  >
+    Co-stream captions aren't enabled for your account yet.
+  </div>
+
+  <div :if={@feature_enabled}>
+    <div
+      :if={!@costream_enabled}
+      class="mb-4 rounded-md bg-red-100 border border-red-300 px-4 py-3 text-red-900"
+    >
+      Guest captions are switched off — nothing guests say reaches your viewers
+      until you turn them back on.
+    </div>
+
+    <form phx-submit="create_guest" class="mb-6 flex items-end gap-3">
+      <label class="block grow max-w-xs">
+        <span class="block text-sm font-medium mb-1 dark:text-gray-200">Guest name</span>
+        <input
+          type="text"
+          name="name"
+          value={@new_guest_name}
+          maxlength="50"
+          required
+          placeholder="e.g. Alice"
+          class="w-full rounded border-gray-300 dark:bg-gray-800 dark:text-white"
+        />
+      </label>
+      <button
+        type="submit"
+        class="rounded bg-purple-700 px-4 py-2 font-semibold text-white hover:bg-purple-800"
+      >
+        Create invite link
+      </button>
+      <span class="text-sm text-gray-500 pb-2">
+        {length(@guests)}/{StreamClosedCaptionerPhoenix.Costream.max_active_guests()} guests
+      </span>
+    </form>
+
+    <p :if={@guests == []} class="text-gray-500">
+      No guests yet — create an invite link and send it to your co-streamer.
+    </p>
+
+    <ul class="space-y-4">
+      <li
+        :for={guest <- @guests}
+        id={"guest-#{guest.id}"}
+        class="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-4"
+      >
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="font-semibold dark:text-white">{guest.name}</span>
+          <span class={[
+            "rounded-full px-2 py-0.5 text-xs",
+            (guest_connected?(@connected_ids, guest) && "bg-green-200 text-green-800") ||
+              "bg-gray-200 text-gray-600"
+          ]}>
+            {if guest_connected?(@connected_ids, guest), do: "Connected", else: "Offline"}
+          </span>
+          <span
+            :if={guest.muted}
+            class="rounded-full bg-red-200 px-2 py-0.5 text-xs text-red-800"
+          >
+            Muted
+          </span>
+
+          <div class="ml-auto flex gap-2">
+            <button
+              type="button"
+              phx-click="toggle_mute"
+              phx-value-id={guest.id}
+              class="rounded border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              {if guest.muted, do: "Unmute", else: "Mute"}
+            </button>
+            <button
+              type="button"
+              phx-click="revoke"
+              phx-value-id={guest.id}
+              data-confirm={"Remove #{guest.name}? Their link stops working immediately."}
+              class="rounded border border-red-300 px-3 py-1 text-sm text-red-700 hover:bg-red-50 dark:hover:bg-red-900/30"
+            >
+              Kick &amp; revoke
+            </button>
+          </div>
+        </div>
+
+        <div class="mt-3 flex gap-2">
+          <input
+            id={"guest-link-#{guest.id}"}
+            type="text"
+            readonly
+            value={guest_url(guest)}
+            onclick="this.select()"
+            class="w-full rounded bg-gray-100 dark:bg-gray-800 px-2 py-1 text-xs text-gray-600 dark:text-gray-300"
+          />
+          <button
+            id={"guest-link-copy-#{guest.id}"}
+            type="button"
+            phx-hook="CopyToClipboard"
+            data-copy-target={"guest-link-#{guest.id}"}
+            class="shrink-0 rounded bg-gray-200 dark:bg-gray-700 px-3 py-1 text-sm dark:text-gray-200"
+          >
+            Copy
+          </button>
+        </div>
+
+        <div
+          :if={live_caption = @live_text[guest.id]}
+          class="mt-3 rounded bg-gray-50 dark:bg-gray-800 p-3 text-sm"
+        >
+          <p class="dark:text-gray-100">{live_caption.final}</p>
+          <p class="italic text-gray-500">{live_caption.interim}</p>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.html.heex
@@ -146,8 +146,9 @@
   </div>
 </div>
 
-<div
+<button
   :if={msg = Phoenix.Flash.get(@flash, :error)}
+  type="button"
   id="costream-toast-error"
   class="toast toast--error"
   data-key="error"
@@ -155,6 +156,7 @@
   phx-click="clear_flash"
   phx-value-key="error"
   role="alert"
+  aria-label="Dismiss error message"
 >
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
     <path
@@ -164,4 +166,4 @@
     />
   </svg>
   {msg}
-</div>
+</button>

--- a/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.html.heex
+++ b/lib/stream_closed_captioner_phoenix_web/live/costream_live/index.html.heex
@@ -1,8 +1,9 @@
-<div class="max-w-4xl mx-auto px-4 py-8">
-  <div class="mb-6 flex items-start justify-between gap-4">
+<header class="page-head">
+  <div class="wrap page-head__in">
     <div>
-      <h1 class="text-2xl font-bold dark:text-white">Co-stream Captions</h1>
-      <p class="text-gray-600 dark:text-gray-300">
+      <span class="eyebrow">Account · Co-stream</span>
+      <h1 class="h1">Co-stream Captions</h1>
+      <p>
         Invite guests with a personal link. Their speech is captioned in their
         browser and shown to viewers alongside yours.
       </p>
@@ -11,132 +12,137 @@
       :if={@feature_enabled}
       type="button"
       phx-click="toggle_kill_switch"
-      class={[
-        "shrink-0 rounded px-4 py-2 font-semibold text-white",
-        (@costream_enabled && "bg-green-600 hover:bg-green-700") ||
-          "bg-red-600 hover:bg-red-700"
-      ]}
+      class={["btn", (@costream_enabled && "btn--primary") || "btn-warning"]}
     >
       {if @costream_enabled, do: "Guest captions ON", else: "Guest captions OFF"}
     </button>
   </div>
+</header>
 
-  <div
-    :if={!@feature_enabled}
-    class="rounded-md bg-yellow-100 border border-yellow-300 px-4 py-3 text-yellow-900"
-  >
-    Co-stream captions aren't enabled for your account yet.
-  </div>
-
-  <div :if={@feature_enabled}>
-    <div
-      :if={!@costream_enabled}
-      class="mb-4 rounded-md bg-red-100 border border-red-300 px-4 py-3 text-red-900"
-    >
-      Guest captions are switched off — nothing guests say reaches your viewers
-      until you turn them back on.
+<div class="wrap">
+  <section :if={!@feature_enabled} class="card">
+    <div class="card__body">
+      <p>Co-stream captions aren't enabled for your account yet.</p>
     </div>
+  </section>
 
-    <form phx-submit="create_guest" class="mb-6 flex items-end gap-3">
-      <label class="block grow max-w-xs">
-        <span class="block text-sm font-medium mb-1 dark:text-gray-200">Guest name</span>
-        <input
-          type="text"
-          name="name"
-          value={@new_guest_name}
-          maxlength="50"
-          required
-          placeholder="e.g. Alice"
-          class="w-full rounded border-gray-300 dark:bg-gray-800 dark:text-white"
-        />
-      </label>
-      <button
-        type="submit"
-        class="rounded bg-purple-700 px-4 py-2 font-semibold text-white hover:bg-purple-800"
-      >
-        Create invite link
-      </button>
-      <span class="text-sm text-gray-500 pb-2">
-        {length(@guests)}/{StreamClosedCaptionerPhoenix.Costream.max_active_guests()} guests
-      </span>
-    </form>
+  <div :if={@feature_enabled} class="cards">
+    <section :if={!@costream_enabled} class="card">
+      <div class="card__body">
+        <p>
+          Guest captions are switched off — nothing guests say reaches your
+          viewers until you turn them back on.
+        </p>
+      </div>
+    </section>
 
-    <p :if={@guests == []} class="text-gray-500">
-      No guests yet — create an invite link and send it to your co-streamer.
-    </p>
-
-    <ul class="space-y-4">
-      <li
-        :for={guest <- @guests}
-        id={"guest-#{guest.id}"}
-        class="rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-4"
-      >
-        <div class="flex flex-wrap items-center gap-2">
-          <span class="font-semibold dark:text-white">{guest.name}</span>
-          <span class={[
-            "rounded-full px-2 py-0.5 text-xs",
-            (guest_connected?(@connected_ids, guest) && "bg-green-200 text-green-800") ||
-              "bg-gray-200 text-gray-600"
-          ]}>
-            {if guest_connected?(@connected_ids, guest), do: "Connected", else: "Offline"}
-          </span>
-          <span
-            :if={guest.muted}
-            class="rounded-full bg-red-200 px-2 py-0.5 text-xs text-red-800"
-          >
-            Muted
-          </span>
-
-          <div class="ml-auto flex gap-2">
-            <button
-              type="button"
-              phx-click="toggle_mute"
-              phx-value-id={guest.id}
-              class="rounded border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
-            >
-              {if guest.muted, do: "Unmute", else: "Mute"}
-            </button>
-            <button
-              type="button"
-              phx-click="revoke"
-              phx-value-id={guest.id}
-              data-confirm={"Remove #{guest.name}? Their link stops working immediately."}
-              class="rounded border border-red-300 px-3 py-1 text-sm text-red-700 hover:bg-red-50 dark:hover:bg-red-900/30"
-            >
-              Kick &amp; revoke
-            </button>
+    <section class="card">
+      <div class="card__head">
+        <h2>Invite a guest</h2>
+        <p>
+          You choose the name viewers see. Send each link privately — anyone
+          holding it can caption on your stream while you're live.
+        </p>
+      </div>
+      <div class="card__body">
+        <form phx-submit="create_guest" class="field">
+          <label for="guest-name-input">Guest name</label>
+          <div class="addrow">
+            <input
+              id="guest-name-input"
+              type="text"
+              name="name"
+              value={@new_guest_name}
+              maxlength="50"
+              required
+              placeholder="e.g. Alice"
+            />
+            <button type="submit" class="btn btn--primary">Create invite link</button>
           </div>
-        </div>
+        </form>
+        <p class="card__desc" style="margin-top: 10px;">
+          {length(@guests)}/{StreamClosedCaptionerPhoenix.Costream.max_active_guests()} guests
+        </p>
+      </div>
+    </section>
 
-        <div class="mt-3 flex gap-2">
-          <input
-            id={"guest-link-#{guest.id}"}
-            type="text"
-            readonly
-            value={guest_url(guest)}
-            onclick="this.select()"
-            class="w-full rounded bg-gray-100 dark:bg-gray-800 px-2 py-1 text-xs text-gray-600 dark:text-gray-300"
-          />
-          <button
-            id={"guest-link-copy-#{guest.id}"}
-            type="button"
-            phx-hook="CopyToClipboard"
-            data-copy-target={"guest-link-#{guest.id}"}
-            class="shrink-0 rounded bg-gray-200 dark:bg-gray-700 px-3 py-1 text-sm dark:text-gray-200"
-          >
-            Copy
-          </button>
-        </div>
+    <section class="card">
+      <div class="card__head">
+        <h2>Your guests</h2>
+        <p>Watch their captions live, mute anyone instantly, or revoke a link for good.</p>
+      </div>
+      <div class="card__body">
+        <p :if={@guests == []} class="chips__empty">
+          No guests yet — create an invite link and send it to your co-streamer.
+        </p>
 
-        <div
-          :if={live_caption = @live_text[guest.id]}
-          class="mt-3 rounded bg-gray-50 dark:bg-gray-800 p-3 text-sm"
-        >
-          <p class="dark:text-gray-100">{live_caption.final}</p>
-          <p class="italic text-gray-500">{live_caption.interim}</p>
-        </div>
-      </li>
-    </ul>
+        <ul :if={@guests != []} class="cards" style="list-style: none; padding: 0; margin: 0;">
+          <li :for={guest <- @guests} id={"guest-#{guest.id}"} class="card">
+            <div class="card__body">
+              <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 10px;">
+                <strong>{guest.name}</strong>
+                <span class={[
+                  "badge",
+                  guest_connected?(@connected_ids, guest) && "badge-live"
+                ]}>
+                  {if guest_connected?(@connected_ids, guest), do: "Connected", else: "Offline"}
+                </span>
+                <span :if={guest.muted} class="badge">Muted</span>
+
+                <div style="margin-left: auto; display: flex; gap: 8px;">
+                  <button
+                    type="button"
+                    phx-click="toggle_mute"
+                    phx-value-id={guest.id}
+                    class="btn btn--ghost btn--sm"
+                  >
+                    {if guest.muted, do: "Unmute", else: "Mute"}
+                  </button>
+                  <button
+                    type="button"
+                    phx-click="revoke"
+                    phx-value-id={guest.id}
+                    data-confirm={"Remove #{guest.name}? Their link stops working immediately."}
+                    class="btn btn-warning btn--sm"
+                  >
+                    Kick &amp; revoke
+                  </button>
+                </div>
+              </div>
+
+              <div class="addrow" style="margin-top: 12px;">
+                <input
+                  id={"guest-link-#{guest.id}"}
+                  type="text"
+                  readonly
+                  value={guest_url(guest)}
+                  onclick="this.select()"
+                  aria-label={"Invite link for #{guest.name}"}
+                />
+                <button
+                  id={"guest-link-copy-#{guest.id}"}
+                  type="button"
+                  phx-hook="CopyToClipboard"
+                  data-copy-target={"guest-link-#{guest.id}"}
+                  class="btn btn--ghost"
+                >
+                  Copy
+                </button>
+              </div>
+
+              <div
+                :if={live_caption = @live_text[guest.id]}
+                class="chips"
+                style="margin-top: 12px; display: block;"
+              >
+                <p style="margin: 0;">{live_caption.final}</p>
+                <p style="margin: 0; opacity: 0.6; font-style: italic;">{live_caption.interim}</p>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
   </div>
 </div>
 

--- a/lib/stream_closed_captioner_phoenix_web/router.ex
+++ b/lib/stream_closed_captioner_phoenix_web/router.ex
@@ -122,6 +122,8 @@ defmodule StreamClosedCaptionerPhoenixWeb.Router do
       live("/captions/:token", CaptionSourceLive.Show, :show)
     end
 
+    get("/costream/:token", CostreamGuestController, :show)
+
     get("/privacy", PrivacyController, :index)
     get("/terms", TermsController, :index)
     get("/showcase", ShowcaseController, :index)
@@ -239,6 +241,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.Router do
         root_layout: {StreamClosedCaptionerPhoenixWeb.Layouts, :scc_root},
         layout: {StreamClosedCaptionerPhoenixWeb.Layouts, :scc} do
         live("/caption-settings", CaptionSettingsLive.Index, :show)
+        live("/costream", CostreamLive.Index, :index)
       end
 
       live("/credit-history", CreditHistoryLive)

--- a/lib/stream_closed_captioner_phoenix_web/schema.ex
+++ b/lib/stream_closed_captioner_phoenix_web/schema.ex
@@ -74,6 +74,14 @@ defmodule StreamClosedCaptionerPhoenixWeb.Schema do
     field(:translations, :json)
   end
 
+  @desc "A co-streamer guest's captions"
+  object :costream_caption do
+    field(:guest_id, :id)
+    field(:name, :string)
+    field(:interim, :string)
+    field(:final, :string)
+  end
+
   query do
     # Add queries here. Example
     import_fields(:accounts_queries)
@@ -111,6 +119,17 @@ defmodule StreamClosedCaptionerPhoenixWeb.Schema do
       # If needed, you can also provide a list of topics:
       #   {:ok, topic: ["absinthe-graphql/absinthe", "elixir-lang/elixir"]}
       # Absinthe.Subscription.publish(StreamClosedCaptionerPhoenixWeb.Endpoint, %{ interim: "hello", final: "final" }, new_twitch_caption: "1")
+      config(fn args, _ ->
+        {:ok, topic: args.channel_id}
+      end)
+    end
+
+    # Guest (co-streamer) captions ride a separate subscription so extension
+    # bundles released before this feature — whose hardcoded query selects
+    # only new_twitch_caption — never receive unattributed guest text.
+    field :new_costream_caption, :costream_caption do
+      arg(:channel_id, non_null(:id))
+
       config(fn args, _ ->
         {:ok, topic: args.channel_id}
       end)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,9 +1,23 @@
 # Active Context
 
 ## Current Focus
-Setting up comprehensive development documentation and instruction files for the Stream Closed Captioner Phoenix project.
+Co-streamer guest captions shipped on branch `claude/costreamer-captions-stcu3m`
+(2026-07-12), pending rollout: run migration → enable `:costream_captions`
+flag → release updated extension version.
 
 ## Recent Changes
+- **Co-streamer guest captions** (2026-07-12): `Costream` context +
+  `costream_guests` table (per-guest signed links, host-assigned names,
+  revoke/mute state on the row); `CostreamChannel` (`costream:HOST_ID`,
+  per-guest Hammer rate limit, gated on host-active + flag + kill switch);
+  slim `pipeline_to(:costream, ...)` (host censoring only, no
+  pirate/translate); separate `new_costream_caption` GraphQL subscription
+  (old extension bundles untouched by design); public guest page at
+  `/costream/:token` (Web Speech API); host monitor LiveView at
+  `/users/costream` (live text, mute/kick via intercepted broadcasts);
+  OBS overlay renders guest finals name-prefixed. ADR:
+  `docs/adr/0001-costream-guest-captions.md`. User guide draft:
+  `docs/costream-captions-user-guide.md`.
 - Created Elixir/Phoenix instruction file with comprehensive coding guidelines
 - Establishing memory bank structure for project knowledge
 - Documenting system architecture and patterns

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -21,6 +21,12 @@
 - **Transcript Storage**: Caption history saved to database
 - **OBS Integration**: WebSocket communication with OBS Studio
 - **Zoom Integration**: Caption support for Zoom meetings
+- **Co-Streamer Guest Captions**: Per-guest shareable links, guest browser
+  captioning (Web Speech), host censoring only (no translate/pirate),
+  separate `new_costream_caption` subscription, host mute/kick dashboard,
+  OBS overlay support — built and tested, gated behind the
+  `:costream_captions` feature flag + `costream_enabled` kill switch
+  (see `docs/adr/0001-costream-guest-captions.md`)
 
 ### Infrastructure ✅
 - **Database**: PostgreSQL with Ecto migrations

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -103,6 +103,29 @@ Browser Mic → Speech Recognition → CaptionsChannel
         LiveView Updates                          Viewer Overlay
 ```
 
+### Co-Streamer Guest Caption Flow (parallel, slimmer path)
+```
+Guest Browser Mic → Web Speech API → CostreamChannel (costream:HOST_ID)
+                                            ↓
+                     gates: muted? → rate limit (Hammer, per guest)
+                            → host active? (UserTracker)
+                            → :costream_captions flag + costream_enabled switch
+                                            ↓
+                          pipeline_to(:costream, host, message)
+                          (HOST's censoring only — no pirate, no translate)
+                                            ↓
+        ┌───────────────────────────┬──────────────────────────────┐
+        ↓                           ↓                              ↓
+  Absinthe Subscription      caption_source:HOST PubSub    costream_monitor:HOST
+  (new_costream_caption —    (OBS overlay, finals only,    (host LiveView:
+  separate so old extension  name-prefixed)                live text, mute/kick)
+  bundles never see guests)
+```
+Mute/kick: host LiveView → `Endpoint.broadcast/3` control events
+(`guest_muted`/`guest_kicked`) → intercepted in guest channel processes
+(cluster-safe). Guest auth: per-guest `Phoenix.Token` link + live DB state
+(revoked/muted re-checked on connect and join). See ADR-0001.
+
 ### Authentication Flow
 ```
 User → Ueberauth (Twitch OAuth) → Guardian (JWT) →

--- a/priv/repo/migrations/20260712002700_add_costream_support.exs
+++ b/priv/repo/migrations/20260712002700_add_costream_support.exs
@@ -1,0 +1,20 @@
+defmodule StreamClosedCaptionerPhoenix.Repo.Migrations.AddCostreamSupport do
+  use Ecto.Migration
+
+  def change do
+    create table(:costream_guests) do
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :name, :string, null: false
+      add :muted, :boolean, default: false, null: false
+      add :revoked_at, :utc_datetime
+
+      timestamps()
+    end
+
+    create index(:costream_guests, [:user_id])
+
+    alter table(:stream_settings) do
+      add :costream_enabled, :boolean, default: true, null: false
+    end
+  end
+end

--- a/test/stream_closed_captioner_phoenix/costream_test.exs
+++ b/test/stream_closed_captioner_phoenix/costream_test.exs
@@ -1,0 +1,128 @@
+defmodule StreamClosedCaptionerPhoenix.CostreamTest do
+  # async: false because FunWithFlags keeps flag state in a shared in-memory cache.
+  use StreamClosedCaptionerPhoenix.DataCase, async: false
+
+  import StreamClosedCaptionerPhoenix.Factory
+
+  alias StreamClosedCaptionerPhoenix.Costream
+
+  setup do
+    # DB toggle rows roll back with the sandbox; flush only the shared cache.
+    on_exit(fn -> FunWithFlags.Store.Cache.flush() end)
+    %{host: insert(:user)}
+  end
+
+  describe "create_guest/2" do
+    test "creates a guest with a trimmed name", %{host: host} do
+      assert {:ok, guest} = Costream.create_guest(host, %{name: "  Alice  "})
+      assert guest.name == "Alice"
+      assert guest.user_id == host.id
+      refute guest.muted
+      assert guest.revoked_at == nil
+    end
+
+    test "requires a name", %{host: host} do
+      assert {:error, %Ecto.Changeset{}} = Costream.create_guest(host, %{name: "   "})
+    end
+
+    test "caps active guests", %{host: host} do
+      for i <- 1..Costream.max_active_guests() do
+        assert {:ok, _} = Costream.create_guest(host, %{name: "Guest #{i}"})
+      end
+
+      assert {:error, :guest_limit_reached} = Costream.create_guest(host, %{name: "One more"})
+    end
+
+    test "revoked guests do not count against the cap", %{host: host} do
+      for i <- 1..Costream.max_active_guests() do
+        assert {:ok, _} = Costream.create_guest(host, %{name: "Guest #{i}"})
+      end
+
+      [guest | _] = Costream.list_active_guests(host)
+      assert {:ok, _} = Costream.revoke_guest(guest)
+      assert {:ok, _} = Costream.create_guest(host, %{name: "Replacement"})
+    end
+  end
+
+  describe "list_active_guests/1" do
+    test "excludes revoked guests and other hosts' guests", %{host: host} do
+      mine = insert(:costream_guest, user: host)
+      revoked = insert(:costream_guest, user: host, revoked_at: DateTime.utc_now(:second))
+      _other = insert(:costream_guest)
+
+      ids = host |> Costream.list_active_guests() |> Enum.map(& &1.id)
+      assert ids == [mine.id]
+      refute revoked.id in ids
+    end
+  end
+
+  describe "get_guest_for/2" do
+    test "scopes to the host", %{host: host} do
+      guest = insert(:costream_guest, user: host)
+      other_hosts_guest = insert(:costream_guest)
+
+      assert {:ok, %{id: id}} = Costream.get_guest_for(host, guest.id)
+      assert id == guest.id
+      assert {:error, :not_found} = Costream.get_guest_for(host, other_hosts_guest.id)
+    end
+  end
+
+  describe "guest tokens" do
+    test "round-trips for an active guest with the flag on", %{host: host} do
+      FunWithFlags.enable(Costream.feature_flag())
+      guest = insert(:costream_guest, user: host)
+
+      token = Costream.guest_token(guest)
+      assert {:ok, verified} = Costream.verify_guest_token(token)
+      assert verified.id == guest.id
+      assert verified.user.id == host.id
+    end
+
+    test "rejects a revoked guest's token", %{host: host} do
+      FunWithFlags.enable(Costream.feature_flag())
+      guest = insert(:costream_guest, user: host)
+      token = Costream.guest_token(guest)
+
+      {:ok, _} = Costream.revoke_guest(guest)
+      assert {:error, :invalid} = Costream.verify_guest_token(token)
+    end
+
+    test "rejects when the feature flag is off", %{host: host} do
+      guest = insert(:costream_guest, user: host)
+      token = Costream.guest_token(guest)
+
+      assert {:error, :feature_disabled} = Costream.verify_guest_token(token)
+    end
+
+    test "rejects garbage tokens" do
+      assert {:error, :invalid} = Costream.verify_guest_token("not-a-token")
+      assert {:error, :invalid} = Costream.verify_guest_token(nil)
+    end
+  end
+
+  describe "publishing_enabled?/1" do
+    test "requires flag and kill switch", %{host: host} do
+      refute Costream.publishing_enabled?(host)
+
+      FunWithFlags.enable(Costream.feature_flag())
+      assert Costream.publishing_enabled?(host)
+
+      {:ok, _} =
+        StreamClosedCaptionerPhoenix.Settings.update_stream_settings(
+          host.stream_settings,
+          %{costream_enabled: false}
+        )
+
+      refute Costream.publishing_enabled?(host)
+    end
+  end
+
+  describe "set_guest_muted/2" do
+    test "flips the muted flag", %{host: host} do
+      guest = insert(:costream_guest, user: host)
+
+      assert {:ok, %{muted: true}} = Costream.set_guest_muted(guest, true)
+      assert {:ok, %{muted: false}} = Costream.set_guest_muted(%{guest | muted: true}, false)
+    end
+  end
+end

--- a/test/stream_closed_captioner_phoenix_web/channels/costream_channel_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/channels/costream_channel_test.exs
@@ -1,0 +1,241 @@
+defmodule StreamClosedCaptionerPhoenixWeb.CostreamChannelTest do
+  # async: false — channel processes hit the DB, FunWithFlags cache is shared,
+  # and UserTracker state is global.
+  use StreamClosedCaptionerPhoenixWeb.ChannelCase, async: false
+
+  import StreamClosedCaptionerPhoenix.Factory
+
+  alias StreamClosedCaptionerPhoenix.Costream
+  alias StreamClosedCaptionerPhoenixWeb.{CostreamChannel, UserSocket, UserTracker}
+
+  setup do
+    FunWithFlags.enable(Costream.feature_flag())
+    # The DB toggle row rolls back with the sandbox; only the shared in-memory
+    # cache leaks across tests, and flushing it needs no DB connection (the
+    # sandbox owner is already gone when on_exit runs for channel tests).
+    on_exit(fn -> FunWithFlags.Store.Cache.flush() end)
+
+    stream_settings = insert(:stream_settings, user: build(:bare_user))
+    host = stream_settings.user
+    guest = insert(:costream_guest, user: host, name: "Alice")
+
+    %{host: host, guest: guest, stream_settings: stream_settings}
+  end
+
+  defp join_as_guest(guest) do
+    {:ok, guest} = Costream.get_active_guest(guest.id)
+
+    UserSocket
+    |> socket("costream_guest", %{costream_guest: guest})
+    |> subscribe_and_join(CostreamChannel, "costream:#{guest.user_id}")
+  end
+
+  defp mark_host_active(host) do
+    UserTracker.track(self(), "active_channels", host.uid, %{
+      last_publish: System.system_time(:second)
+    })
+  end
+
+  describe "join" do
+    test "a guest can join their host's topic", %{guest: guest} do
+      assert {:ok, %{name: "Alice", muted: false}, _socket} = join_as_guest(guest)
+    end
+
+    test "a guest cannot join another host's topic", %{guest: guest} do
+      other_host = insert(:user)
+      {:ok, loaded} = Costream.get_active_guest(guest.id)
+
+      assert {:error, %{reason: "unauthorized"}} =
+               UserSocket
+               |> socket("costream_guest", %{costream_guest: loaded})
+               |> subscribe_and_join(CostreamChannel, "costream:#{other_host.id}")
+    end
+
+    test "a revoked guest cannot rejoin even with a stale socket assign", %{guest: guest} do
+      {:ok, loaded} = Costream.get_active_guest(guest.id)
+      {:ok, _} = Costream.revoke_guest(guest)
+
+      assert {:error, %{reason: "unauthorized"}} =
+               UserSocket
+               |> socket("costream_guest", %{costream_guest: loaded})
+               |> subscribe_and_join(CostreamChannel, "costream:#{guest.user_id}")
+    end
+
+    test "the host can join their own topic read-only", %{host: host} do
+      assert {:ok, _, socket} =
+               UserSocket
+               |> socket("user_id", %{current_user: host})
+               |> subscribe_and_join(CostreamChannel, "costream:#{host.id}")
+
+      ref = push(socket, "publish", %{"interim" => "x", "final" => ""})
+      assert_reply ref, :error, %{reason: "unauthorized"}
+    end
+
+    test "another user cannot join as monitor", %{host: host} do
+      intruder = insert(:user)
+
+      assert {:error, %{reason: "unauthorized"}} =
+               UserSocket
+               |> socket("user_id", %{current_user: intruder})
+               |> subscribe_and_join(CostreamChannel, "costream:#{host.id}")
+    end
+  end
+
+  describe "publish" do
+    test "is gated on the host actively captioning", %{guest: guest} do
+      {:ok, _, socket} = join_as_guest(guest)
+
+      ref = push(socket, "publish", %{"interim" => "hello", "final" => ""})
+      assert_reply ref, :error, %{reason: "host_offline"}
+    end
+
+    test "fans out censored captions when the host is live", %{
+      host: host,
+      guest: guest,
+      stream_settings: stream_settings
+    } do
+      {:ok, _} =
+        StreamClosedCaptionerPhoenix.Settings.update_stream_settings(stream_settings, %{
+          blocklist: ["poopy"]
+        })
+
+      mark_host_active(host)
+      Phoenix.PubSub.subscribe(StreamClosedCaptionerPhoenix.PubSub, "caption_source:#{host.id}")
+
+      Phoenix.PubSub.subscribe(
+        StreamClosedCaptionerPhoenix.PubSub,
+        Costream.monitor_topic(host.id)
+      )
+
+      {:ok, _, socket} = join_as_guest(guest)
+
+      ref = push(socket, "publish", %{"interim" => "", "final" => "hi poopy world"})
+
+      assert_reply ref, :ok, %{name: "Alice", final: final}
+      assert final == "hi ***** world"
+
+      assert_receive {:costream_caption_payload, %{name: "Alice", final: ^final}}
+      assert_receive {:costream_caption, %{name: "Alice", final: ^final}}
+    end
+
+    test "muted guests cannot publish", %{host: host, guest: guest} do
+      {:ok, _} = Costream.set_guest_muted(guest, true)
+      mark_host_active(host)
+
+      {:ok, _, socket} = join_as_guest(guest)
+
+      ref = push(socket, "publish", %{"interim" => "hello", "final" => ""})
+      assert_reply ref, :error, %{reason: "muted"}
+    end
+
+    test "the kill switch silences guests", %{
+      host: host,
+      guest: guest,
+      stream_settings: stream_settings
+    } do
+      {:ok, _} =
+        StreamClosedCaptionerPhoenix.Settings.update_stream_settings(stream_settings, %{
+          costream_enabled: false
+        })
+
+      mark_host_active(host)
+      {:ok, _, socket} = join_as_guest(guest)
+
+      ref = push(socket, "publish", %{"interim" => "hello", "final" => ""})
+      assert_reply ref, :error, %{reason: "disabled"}
+    end
+
+    test "rapid publishes get rate limited", %{host: host, guest: guest} do
+      mark_host_active(host)
+      {:ok, _, socket} = join_as_guest(guest)
+
+      replies =
+        for i <- 1..40 do
+          ref = push(socket, "publish", %{"interim" => "msg #{i}", "final" => ""})
+
+          receive do
+            %Phoenix.Socket.Reply{ref: ^ref, status: status, payload: payload} ->
+              {status, payload}
+          after
+            1000 -> flunk("no reply for publish #{i}")
+          end
+        end
+
+      assert Enum.any?(replies, fn
+               {:error, %{reason: "rate_limited"}} -> true
+               _ -> false
+             end)
+    end
+  end
+
+  describe "control events" do
+    test "guest_muted broadcast mutes the running channel", %{host: host, guest: guest} do
+      mark_host_active(host)
+      {:ok, _, socket} = join_as_guest(guest)
+
+      StreamClosedCaptionerPhoenixWeb.Endpoint.broadcast(
+        Costream.channel_topic(host.id),
+        "guest_muted",
+        %{guest_id: guest.id, muted: true}
+      )
+
+      assert_push "muted", %{muted: true}
+
+      ref = push(socket, "publish", %{"interim" => "hello", "final" => ""})
+      assert_reply ref, :error, %{reason: "muted"}
+    end
+
+    test "guest_kicked broadcast pushes kicked and stops the channel", %{
+      host: host,
+      guest: guest
+    } do
+      {:ok, _, socket} = join_as_guest(guest)
+      Process.unlink(socket.channel_pid)
+      monitor = Process.monitor(socket.channel_pid)
+
+      StreamClosedCaptionerPhoenixWeb.Endpoint.broadcast(
+        Costream.channel_topic(host.id),
+        "guest_kicked",
+        %{guest_id: guest.id}
+      )
+
+      assert_push "kicked", %{}
+      assert_receive {:DOWN, ^monitor, :process, _pid, _reason}
+    end
+
+    test "control events for another guest are ignored", %{host: host, guest: guest} do
+      other_guest = insert(:costream_guest, user: host, name: "Bob")
+      {:ok, _, _socket} = join_as_guest(guest)
+
+      StreamClosedCaptionerPhoenixWeb.Endpoint.broadcast(
+        Costream.channel_topic(host.id),
+        "guest_kicked",
+        %{guest_id: other_guest.id}
+      )
+
+      refute_push "kicked", %{}
+    end
+  end
+
+  describe "monitor notifications" do
+    test "join and leave broadcast to the monitor topic", %{host: host, guest: guest} do
+      Phoenix.PubSub.subscribe(
+        StreamClosedCaptionerPhoenix.PubSub,
+        Costream.monitor_topic(host.id)
+      )
+
+      {:ok, _, socket} = join_as_guest(guest)
+      guest_id = guest.id
+      assert_receive {:costream_guest_joined, %{guest_id: ^guest_id, name: "Alice"}}
+
+      Process.unlink(socket.channel_pid)
+      leave(socket)
+      assert_receive {:costream_guest_left, %{guest_id: ^guest_id}}
+    end
+
+    test "guests receive host_status on join", %{guest: guest} do
+      {:ok, _, _socket} = join_as_guest(guest)
+      assert_push "host_status", %{active: false}
+    end
+  end
+end

--- a/test/stream_closed_captioner_phoenix_web/controllers/costream_guest_controller_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/controllers/costream_guest_controller_test.exs
@@ -1,0 +1,51 @@
+defmodule StreamClosedCaptionerPhoenixWeb.CostreamGuestControllerTest do
+  # async: false because FunWithFlags keeps flag state in a shared in-memory cache.
+  use StreamClosedCaptionerPhoenixWeb.ConnCase, async: false
+
+  import StreamClosedCaptionerPhoenix.Factory
+
+  alias StreamClosedCaptionerPhoenix.Costream
+
+  setup do
+    # DB toggle rows roll back with the sandbox; flush only the shared cache.
+    on_exit(fn -> FunWithFlags.Store.Cache.flush() end)
+    %{host: insert(:user)}
+  end
+
+  test "renders the guest dashboard for a valid link", %{conn: conn, host: host} do
+    FunWithFlags.enable(Costream.feature_flag())
+    guest = insert(:costream_guest, user: host, name: "Alice")
+
+    conn = get(conn, ~p"/costream/#{Costream.guest_token(guest)}")
+
+    response = html_response(conn, 200)
+    assert response =~ "You're captioning as Alice"
+    assert response =~ "data-controller=\"costream\""
+    assert response =~ "data-costream-host-id-value=\"#{host.id}\""
+  end
+
+  test "renders the invalid page for a revoked link", %{conn: conn, host: host} do
+    FunWithFlags.enable(Costream.feature_flag())
+    guest = insert(:costream_guest, user: host)
+    token = Costream.guest_token(guest)
+    {:ok, _} = Costream.revoke_guest(guest)
+
+    conn = get(conn, ~p"/costream/#{token}")
+
+    assert html_response(conn, 404) =~ "This co-stream link isn't valid"
+  end
+
+  test "renders the invalid page when the feature flag is off", %{conn: conn, host: host} do
+    guest = insert(:costream_guest, user: host)
+
+    conn = get(conn, ~p"/costream/#{Costream.guest_token(guest)}")
+
+    assert html_response(conn, 404) =~ "This co-stream link isn't valid"
+  end
+
+  test "renders the invalid page for garbage tokens", %{conn: conn} do
+    conn = get(conn, ~p"/costream/garbage")
+
+    assert html_response(conn, 404)
+  end
+end

--- a/test/stream_closed_captioner_phoenix_web/live/caption_source_live_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/live/caption_source_live_test.exs
@@ -477,6 +477,76 @@ defmodule StreamClosedCaptionerPhoenixWeb.CaptionSourceLiveTest do
     end
   end
 
+  describe "co-streamer guest captions" do
+    setup :create_caption_source
+
+    defp broadcast_costream(stream_settings, caption) do
+      Phoenix.PubSub.broadcast(
+        StreamClosedCaptionerPhoenix.PubSub,
+        "caption_source:#{stream_settings.user_id}",
+        {:costream_caption_payload, caption}
+      )
+    end
+
+    test "renders guest finals name-prefixed alongside host text", %{
+      conn: conn,
+      token: token,
+      stream_settings: stream_settings
+    } do
+      {:ok, view, _html} = live(conn, "/captions/#{token}")
+
+      broadcast_caption(stream_settings, %CaptionsPayload{interim: "", final: "host line"})
+
+      broadcast_costream(stream_settings, %{
+        guest_id: 1,
+        name: "Alice",
+        interim: "",
+        final: "guest line"
+      })
+
+      html = render(view)
+      assert html =~ "host line"
+      assert html =~ "Alice: guest line"
+    end
+
+    test "guest interim frames are ignored on the overlay", %{
+      conn: conn,
+      token: token,
+      stream_settings: stream_settings
+    } do
+      {:ok, view, _html} = live(conn, "/captions/#{token}")
+
+      broadcast_costream(stream_settings, %{
+        guest_id: 1,
+        name: "Alice",
+        interim: "still talking",
+        final: ""
+      })
+
+      refute render(view) =~ "still talking"
+    end
+
+    test "guest finals honor the caption delay", %{conn: conn} do
+      stream_settings =
+        insert(:stream_settings, user: build(:bare_user), caption_delay: 60)
+        |> Settings.get_or_generate_caption_source_token!()
+
+      {:ok, view, _html} = live(conn, "/captions/#{stream_settings.caption_source_token}")
+
+      broadcast_costream(stream_settings, %{
+        guest_id: 1,
+        name: "Alice",
+        interim: "",
+        final: "delayed guest text"
+      })
+
+      refute render(view) =~ "delayed guest text"
+
+      send(view.pid, {:apply_costream_caption, "Alice: delayed guest text"})
+      assert render(view) =~ "Alice: delayed guest text"
+    end
+  end
+
   describe "caption delay" do
     test "defers rendering when caption_delay is set", %{conn: conn} do
       # 60s delay: long enough that the deferred timer cannot fire during the

--- a/test/stream_closed_captioner_phoenix_web/live/costream_live_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/live/costream_live_test.exs
@@ -47,10 +47,12 @@ defmodule StreamClosedCaptionerPhoenixWeb.CostreamLiveTest do
     |> form("form[phx-submit=create_guest]", %{"name" => "Extra"})
     |> render_submit()
 
-    # The layout doesn't render LiveView flashes, so assert on the effect:
-    # no fifth guest was created or rendered.
     assert length(Costream.list_active_guests(user)) == Costream.max_active_guests()
-    refute render(view) =~ "Extra"
+
+    rendered = render(view)
+    refute rendered =~ "Extra"
+    # The template renders the :error flash itself (the scc layout doesn't).
+    assert rendered =~ "at most #{Costream.max_active_guests()} active guests"
   end
 
   test "mutes and unmutes a guest", %{conn: conn, user: user} do

--- a/test/stream_closed_captioner_phoenix_web/live/costream_live_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/live/costream_live_test.exs
@@ -1,0 +1,137 @@
+defmodule StreamClosedCaptionerPhoenixWeb.CostreamLiveTest do
+  # async: false because FunWithFlags keeps flag state in a shared in-memory cache.
+  use StreamClosedCaptionerPhoenixWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import StreamClosedCaptionerPhoenix.Factory
+
+  alias StreamClosedCaptionerPhoenix.Costream
+
+  setup :register_and_log_in_user
+
+  setup %{user: user} do
+    FunWithFlags.enable(Costream.feature_flag())
+    # DB toggle rows roll back with the sandbox; flush only the shared cache.
+    on_exit(fn -> FunWithFlags.Store.Cache.flush() end)
+    %{user: StreamClosedCaptionerPhoenix.Repo.preload(user, :stream_settings)}
+  end
+
+  test "shows a notice when the feature flag is off", %{conn: conn, user: user} do
+    FunWithFlags.disable(Costream.feature_flag(), for_actor: user)
+    FunWithFlags.disable(Costream.feature_flag())
+
+    {:ok, _view, html} = live(conn, ~p"/users/costream")
+    assert html =~ "aren&#39;t enabled for your account yet"
+  end
+
+  test "creates a guest link", %{conn: conn, user: user} do
+    {:ok, view, _html} = live(conn, ~p"/users/costream")
+
+    view
+    |> form("form[phx-submit=create_guest]", %{"name" => "Alice"})
+    |> render_submit()
+
+    assert [%{name: "Alice"}] = Costream.list_active_guests(user)
+    assert render(view) =~ "Alice"
+    assert render(view) =~ "/costream/"
+  end
+
+  test "enforces the guest cap", %{conn: conn, user: user} do
+    for i <- 1..Costream.max_active_guests() do
+      {:ok, _} = Costream.create_guest(user, %{name: "Guest #{i}"})
+    end
+
+    {:ok, view, _html} = live(conn, ~p"/users/costream")
+
+    view
+    |> form("form[phx-submit=create_guest]", %{"name" => "Extra"})
+    |> render_submit()
+
+    # The layout doesn't render LiveView flashes, so assert on the effect:
+    # no fifth guest was created or rendered.
+    assert length(Costream.list_active_guests(user)) == Costream.max_active_guests()
+    refute render(view) =~ "Extra"
+  end
+
+  test "mutes and unmutes a guest", %{conn: conn, user: user} do
+    {:ok, guest} = Costream.create_guest(user, %{name: "Alice"})
+
+    {:ok, view, _html} = live(conn, ~p"/users/costream")
+
+    view
+    |> element("#guest-#{guest.id} button[phx-click=toggle_mute]")
+    |> render_click()
+
+    assert {:ok, %{muted: true}} = Costream.get_guest_for(user, guest.id)
+    assert render(view) =~ "Unmute"
+  end
+
+  test "revokes a guest", %{conn: conn, user: user} do
+    {:ok, guest} = Costream.create_guest(user, %{name: "Alice"})
+
+    {:ok, view, _html} = live(conn, ~p"/users/costream")
+
+    view
+    |> element("#guest-#{guest.id} button[phx-click=revoke]")
+    |> render_click()
+
+    assert Costream.list_active_guests(user) == []
+    refute has_element?(view, "#guest-#{guest.id}")
+  end
+
+  test "toggles the kill switch", %{conn: conn, user: user} do
+    {:ok, view, html} = live(conn, ~p"/users/costream")
+    assert html =~ "Guest captions ON"
+
+    view
+    |> element("button[phx-click=toggle_kill_switch]")
+    |> render_click()
+
+    assert render(view) =~ "Guest captions OFF"
+
+    {:ok, settings} =
+      StreamClosedCaptionerPhoenix.Settings.get_stream_settings_by_user_id(user.id)
+
+    refute settings.costream_enabled
+  end
+
+  test "shows live guest caption text from the monitor topic", %{conn: conn, user: user} do
+    {:ok, guest} = Costream.create_guest(user, %{name: "Alice"})
+
+    {:ok, view, _html} = live(conn, ~p"/users/costream")
+
+    Phoenix.PubSub.broadcast(
+      StreamClosedCaptionerPhoenix.PubSub,
+      Costream.monitor_topic(user.id),
+      {:costream_caption,
+       %{guest_id: guest.id, name: "Alice", interim: "typing", final: "hello there"}}
+    )
+
+    rendered = render(view)
+    assert rendered =~ "hello there"
+    assert rendered =~ "typing"
+  end
+
+  test "marks guests connected on join broadcasts", %{conn: conn, user: user} do
+    {:ok, guest} = Costream.create_guest(user, %{name: "Alice"})
+
+    {:ok, view, html} = live(conn, ~p"/users/costream")
+    assert html =~ "Offline"
+
+    Phoenix.PubSub.broadcast(
+      StreamClosedCaptionerPhoenix.PubSub,
+      Costream.monitor_topic(user.id),
+      {:costream_guest_joined, %{guest_id: guest.id, name: "Alice"}}
+    )
+
+    assert render(view) =~ "Connected"
+
+    Phoenix.PubSub.broadcast(
+      StreamClosedCaptionerPhoenix.PubSub,
+      Costream.monitor_topic(user.id),
+      {:costream_guest_left, %{guest_id: guest.id}}
+    )
+
+    assert render(view) =~ "Offline"
+  end
+end


### PR DESCRIPTION
## Summary

Lets a host invite up to 4 co-streamer guests via per-guest shareable links. Guests caption in-browser (Web Speech API) on a public `/costream/:token` page — no account needed — and their captions fan out to viewers alongside the host's, name-attributed. The host keeps full live control (mute, kick, global kill switch), and the whole feature ships behind the `:costream_captions` feature flag.

## How it works

- **`Costream` context + `costream_guests` table** — per-guest `Phoenix.Token` links carry only the guest id; revocation/mute/display-name live on the DB row, so host actions are immediate and tokens never rotate. Cap of 4 active guests.
- **`CostreamChannel`** (`costream:HOST_ID`) — guest sockets (link-token auth) publish; the host's socket joins read-only. Publishes are rate limited per guest (Hammer, 15/sec) and gated on the host actively captioning (`UserTracker`), the feature flag, and the `costream_enabled` kill switch on stream settings. Mute/kick arrive as intercepted `Endpoint.broadcast/3` control events (cluster-safe). Revoked guests can't rejoin on stale sockets.
- **Slim pipeline path** — `pipeline_to(:costream, host, msg)` applies the host's censoring only (no pirate mode, no translations) to keep per-guest cost near zero.
- **Separate `new_costream_caption` GraphQL subscription** — deliberate backwards-compatibility choice: released extension bundles hardcode the `new_twitch_caption` selection set and would render guest text unattributed as the streamer's own words. Old bundles are structurally unaffected.
- **Host control room** at `/users/costream` (LiveView): create/revoke links, live guest text, connected status, mute/kick, global on/off.
- **OBS overlay** renders guest finals name-prefixed (guest interim intentionally dropped — a single interim line can't interleave speakers), honoring caption delay.

Docs included: ADR (`docs/adr/0001-costream-guest-captions.md`), squad decision-log entry, memory-bank updates, and a draft site guide (`docs/costream-captions-user-guide.md`). Also adds a `.mcp.json` (env-var-driven, no secrets).

## Rollout

1. Migration runs via the release entrypoint (`costream_guests` table + `stream_settings.costream_enabled`).
2. Enable `:costream_captions` at `/feature-flags` (per-actor first, then globally).
3. Release the extension counterpart: talk2MeGooseman/stream-closed-captioner-extension#claude/costreamer-captions-stcu3m. Backend can merge/deploy first safely.

## Test plan

- `mix test`: 497 tests + 5 doctests, 0 failures (73 exercise the new paths: token verify/revoke, channel auth for both roles, censoring fan-out, mute/kick control events, rate limiting, host-offline gating, kill switch, LiveView management, overlay rendering + delay).
- Compile clean with `--warnings-as-errors`; `mix format` clean; Credo/Sobelow show only pre-existing findings; esbuild bundles the new guest Stimulus controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9S37dZYFfF7qhkjCohFAN

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9S37dZYFfF7qhkjCohFAN)_