### PR TITLE
test: raise audit-event assertion coverage (24/26 reachable events)

### DIFF
--- a/test/stream_closed_captioner_phoenix/accounts_oauth_test.exs
+++ b/test/stream_closed_captioner_phoenix/accounts_oauth_test.exs
@@ -3,6 +3,7 @@ defmodule StreamClosedCaptionerPhoenix.AccountsOauthTest do
 
   use StreamClosedCaptionerPhoenix.DataCase, async: false
   import StreamClosedCaptionerPhoenix.AuditHelpers
+  import StreamClosedCaptionerPhoenix.AccountsFixtures
 
   alias StreamClosedCaptionerPhoenix.AccountsOauth
 
@@ -29,7 +30,10 @@ defmodule StreamClosedCaptionerPhoenix.AccountsOauthTest do
         :refresh_token => "12345"
       }
 
-      {:ok, data} = AccountsOauth.find_or_register_user_with_oauth(attrs, creds, nil)
+      {:ok, data} =
+        capture_audit_events(fn ->
+          AccountsOauth.find_or_register_user_with_oauth(attrs, creds, nil)
+        end)
 
       assert data.user.email == attrs["email"]
       assert data.user.uid == attrs["id"]
@@ -37,6 +41,7 @@ defmodule StreamClosedCaptionerPhoenix.AccountsOauthTest do
       assert data.user.access_token == "12345"
 
       assert StreamClosedCaptionerPhoenix.Settings.get_stream_settings_by_user_id!(data.user.id)
+      assert_audit_event("oauth.account_registered")
     end
 
     test "when no current user, finds a user with matching information" do
@@ -57,7 +62,10 @@ defmodule StreamClosedCaptionerPhoenix.AccountsOauthTest do
 
       insert(:user, uid: attrs["id"], provider: "twitch")
 
-      {:ok, data} = AccountsOauth.find_or_register_user_with_oauth(attrs, creds, nil)
+      {:ok, data} =
+        capture_audit_events(fn ->
+          AccountsOauth.find_or_register_user_with_oauth(attrs, creds, nil)
+        end)
 
       assert data.user.uid == attrs["id"]
       refute data.user.email == attrs["email"]
@@ -65,6 +73,7 @@ defmodule StreamClosedCaptionerPhoenix.AccountsOauthTest do
       assert data.user.description == attrs["description"]
       assert data.user.provider == "twitch"
       assert data.user.access_token == "12345"
+      assert_audit_event("oauth.account_refreshed")
     end
 
     test "when current user, connects twitch account if not already connected else where" do
@@ -125,6 +134,86 @@ defmodule StreamClosedCaptionerPhoenix.AccountsOauthTest do
 
       assert {:error, _message} = result
       assert_audit_event("oauth.account_link_failed_already_linked")
+    end
+
+    test "when no current user, fails to register when uid conflicts with an existing user" do
+      existing = insert(:user)
+
+      attrs = %{
+        "id" => existing.uid,
+        "email" => unique_user_email(),
+        "display_name" => "talk2megooseman",
+        "login" => "talk2megooseman",
+        "profile_image_url" => "https://image.com",
+        "description" => "hello world",
+        "offline_image_url" => "https://image.com"
+      }
+
+      creds = %{
+        :access_token => "12345",
+        :refresh_token => "12345"
+      }
+
+      result =
+        capture_audit_events(fn ->
+          AccountsOauth.find_or_register_user_with_oauth(attrs, creds, nil)
+        end)
+
+      assert {:error, _, _changeset, _} = result
+      assert_audit_event("oauth.account_register_failed")
+    end
+
+    test "when current user, fails to link when required oauth fields are missing" do
+      attrs = %{
+        "id" => "12345",
+        "email" => "test@email.com",
+        "login" => "talk2megooseman",
+        "profile_image_url" => "https://image.com",
+        "description" => "hello world",
+        "offline_image_url" => "https://image.com"
+      }
+
+      creds = %{
+        :access_token => "12345",
+        :refresh_token => "12345"
+      }
+
+      current_user = insert(:user, uid: nil, provider: nil)
+
+      result =
+        capture_audit_events(fn ->
+          AccountsOauth.find_or_register_user_with_oauth(attrs, creds, current_user)
+        end)
+
+      assert {:error, _changeset} = result
+      assert_audit_event("oauth.account_link_failed")
+    end
+
+    test "when no current user, fails to link when email matches a different existing account" do
+      existing = insert(:user)
+
+      attrs = %{
+        "id" => "different-uid-12345",
+        "email" => existing.email,
+        "display_name" => "talk2megooseman",
+        "login" => "talk2megooseman",
+        "profile_image_url" => "https://image.com",
+        "description" => "hello world",
+        "offline_image_url" => "https://image.com"
+      }
+
+      creds = %{
+        :access_token => "12345",
+        :refresh_token => "12345"
+      }
+
+      result =
+        capture_audit_events(fn ->
+          AccountsOauth.find_or_register_user_with_oauth(attrs, creds, nil)
+        end)
+
+      assert {:error, _message} = result
+      assert_audit_event("oauth.account_link_failed_email_conflict")
     end
   end
 end

--- a/test/stream_closed_captioner_phoenix/accounts_test.exs
+++ b/test/stream_closed_captioner_phoenix/accounts_test.exs
@@ -303,9 +303,12 @@ defmodule StreamClosedCaptionerPhoenix.AccountsTest do
 
     test "validates current password", %{user: user} do
       {:error, changeset} =
-        Accounts.update_user_password(user, "invalid", %{password: valid_user_password()})
+        capture_audit_events(fn ->
+          Accounts.update_user_password(user, "invalid", %{password: valid_user_password()})
+        end)
 
       assert %{current_password: ["is not valid"]} = errors_on(changeset)
+      assert_audit_event("accounts.password_change_failed")
     end
 
     test "updates the password", %{user: user} do
@@ -440,8 +443,10 @@ defmodule StreamClosedCaptionerPhoenix.AccountsTest do
 
     test "sends token through notification", %{user: user} do
       token =
-        extract_user_token(fn url ->
-          Accounts.deliver_user_reset_password_instructions(user, url)
+        capture_audit_events(fn ->
+          extract_user_token(fn url ->
+            Accounts.deliver_user_reset_password_instructions(user, url)
+          end)
         end)
 
       {:ok, token} = Base.url_decode64(token, padding: false)
@@ -449,6 +454,7 @@ defmodule StreamClosedCaptionerPhoenix.AccountsTest do
       assert user_token.user_id == user.id
       assert user_token.sent_to == user.email
       assert user_token.context == "reset_password"
+      assert_audit_event("accounts.password_reset_instructions_sent")
     end
   end
 
@@ -489,15 +495,19 @@ defmodule StreamClosedCaptionerPhoenix.AccountsTest do
 
     test "validates password", %{user: user} do
       {:error, changeset} =
-        Accounts.reset_user_password(user, %{
-          password: "not 6",
-          password_confirmation: "another"
-        })
+        capture_audit_events(fn ->
+          Accounts.reset_user_password(user, %{
+            password: "not 6",
+            password_confirmation: "another"
+          })
+        end)
 
       assert %{
                password: ["should be at least 6 character(s)"],
                password_confirmation: ["does not match password"]
              } = errors_on(changeset)
+
+      assert_audit_event("accounts.password_reset_failed")
     end
 
     test "validates maximum values for password for security", %{user: user} do
@@ -521,6 +531,19 @@ defmodule StreamClosedCaptionerPhoenix.AccountsTest do
       _ = Accounts.generate_user_session_token(user)
       {:ok, _} = Accounts.reset_user_password(user, %{password: "new valid password"})
       refute Repo.get_by(UserToken, user_id: user.id)
+    end
+  end
+
+  describe "remove_user_provider/1" do
+    test "emits audit event and clears provider fields on success" do
+      user = insert(:user, provider: "twitch", uid: "12345")
+
+      capture_audit_events(fn ->
+        assert {:ok, updated} = Accounts.remove_user_provider(user)
+        assert is_nil(updated.provider)
+      end)
+
+      assert_audit_event("accounts.oauth_unlinked")
     end
   end
 

--- a/test/stream_closed_captioner_phoenix/audit_log_test.exs
+++ b/test/stream_closed_captioner_phoenix/audit_log_test.exs
@@ -1,0 +1,164 @@
+defmodule StreamClosedCaptionerPhoenix.AuditLogTest do
+  use ExUnit.Case, async: false
+
+  import StreamClosedCaptionerPhoenix.AuditHelpers
+
+  alias StreamClosedCaptionerPhoenix.AuditLog
+  alias StreamClosedCaptionerPhoenix.Accounts.User
+
+  describe "redact_deep/1 (via info/2 telemetry metadata)" do
+    test "strips redacted string keys from a flat map" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{"access_token" => "secret", user_id: 1})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      assert metadata.user_id == 1
+      refute Map.has_key?(metadata, "access_token")
+    end
+
+    test "strips redacted atom keys from a flat map" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{
+          user_id: 1,
+          password: "secret",
+          azure_service_key: "abc123"
+        })
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      assert metadata.user_id == 1
+      refute Map.has_key?(metadata, :password)
+      refute Map.has_key?(metadata, :azure_service_key)
+    end
+
+    test "strips both atom and string keys for the same logical field in one map" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{"password" => "b", password: "a"})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      refute Map.has_key?(metadata, :password)
+      refute Map.has_key?(metadata, "password")
+    end
+
+    test "recurses into nested maps, stripping the nested sensitive key" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{user: %{password: "x"}})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      assert Map.has_key?(metadata, :user)
+      refute Map.has_key?(metadata.user, :password)
+    end
+
+    test "keyword list values: the redacted entry is dropped entirely (deletion, same as flat maps)" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{opts: [password: "x", safe: "y"]})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      refute Keyword.has_key?(metadata.opts, :password)
+      assert Keyword.get(metadata.opts, :safe) == "y"
+    end
+
+    test "non-keyword list of 2-tuples with string keys: the entry is kept but its value is masked" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{opts: [{"password", "x"}, {"safe", "y"}]})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      assert {"password", "[REDACTED]"} in metadata.opts
+      assert {"safe", "y"} in metadata.opts
+    end
+
+    test "tuples and lists that aren't key-value shaped pass through without crashing" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{data: {1, 2, 3}, list: [1, 2, 3]})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      assert metadata.data == {1, 2, 3}
+      assert metadata.list == [1, 2, 3]
+    end
+
+    test "non-sensitive values are left untouched, including a value equal to a redacted key name" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{note: "password"})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      assert metadata.note == "password"
+    end
+
+    test "near-miss keys are not redacted (exact-match only)" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{"twitch_access_token" => "secret"})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      assert metadata["twitch_access_token"] == "secret"
+    end
+
+    test "a struct value nested in metadata currently crashes (known limitation; no current call site does this)" do
+      user = %User{password: "secret", access_token: "tok", refresh_token: "reftok"}
+
+      # redact_deep/1's map clause calls Map.new/2 on the value, which raises for
+      # structs (Elixir no longer treats structs as plain enumerable maps here).
+      # No AuditLog.info/2 or warn/2 call site today passes a struct as a metadata
+      # value, so this isn't reachable in production, but it's a real crash risk if
+      # one ever does. Locked in as a regression test rather than silently "fixed"
+      # here, since fixing AuditLog is out of scope for this test-only issue.
+      assert_raise Protocol.UndefinedError, fn ->
+        capture_audit_events(fn ->
+          AuditLog.info("test.event", %{user: user})
+        end)
+      end
+    end
+
+    test "empty map and empty nested list don't crash" do
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      assert metadata.event == "test.event"
+
+      capture_audit_events(fn ->
+        AuditLog.info("test.event", %{data: []})
+      end)
+
+      assert_receive {:audit_event, _measurements, metadata}
+      assert metadata.data == []
+    end
+  end
+
+  describe "format_reason/1" do
+    test "returns atoms unchanged, including nil and booleans" do
+      assert AuditLog.format_reason(:some_atom) == :some_atom
+      assert AuditLog.format_reason(nil) == nil
+      assert AuditLog.format_reason(true) == true
+      assert AuditLog.format_reason(false) == false
+    end
+
+    test "traverses an %Ecto.Changeset{}'s errors" do
+      changeset =
+        User.password_changeset(%User{}, %{password: "short", password_confirmation: "x"})
+
+      refute changeset.valid?
+
+      assert AuditLog.format_reason(changeset) == %{
+               password: ["should be at least %{count} character(s)"],
+               password_confirmation: ["does not match password"]
+             }
+    end
+
+    test "returns binaries unchanged" do
+      assert AuditLog.format_reason("already a string") == "already a string"
+    end
+
+    test "falls back to inspect/2 for any other type" do
+      assert AuditLog.format_reason({:some, :tuple}) == inspect({:some, :tuple}, limit: 5, printable_limit: 100)
+    end
+  end
+end

--- a/test/stream_closed_captioner_phoenix/bits_test.exs
+++ b/test/stream_closed_captioner_phoenix/bits_test.exs
@@ -46,6 +46,7 @@ defmodule StreamClosedCaptionerPhoenix.BitsTest do
 
       assert {:ok, _} = result
       assert_audit_event("bits.translation_activated")
+      assert_audit_event("bits.debit_created")
     end
 
     test "activate_translations_for/1 return :ok if user has minimum balance" do
@@ -118,7 +119,14 @@ defmodule StreamClosedCaptionerPhoenix.BitsTest do
 
     test "create_bits_balance_debit/1 with invalid data returns error changeset" do
       user = insert(:user)
-      assert {:error, %Ecto.Changeset{}} = Bits.create_bits_balance_debit(user, @invalid_attrs)
+
+      result =
+        capture_audit_events(fn ->
+          Bits.create_bits_balance_debit(user, @invalid_attrs)
+        end)
+
+      assert {:error, %Ecto.Changeset{}} = result
+      assert_audit_event("bits.debit_create_failed")
     end
 
     test "get_user_active_debit/1 return a record a debit has occurred in the past 24 hours" do
@@ -504,8 +512,13 @@ defmodule StreamClosedCaptionerPhoenix.BitsTest do
         }
       }
 
-      assert {:error, :retrieve_balance, :no_bits_balance, _} =
-               Bits.process_bits_transaction(user.uid, data)
+      result =
+        capture_audit_events(fn ->
+          Bits.process_bits_transaction(user.uid, data)
+        end)
+
+      assert {:error, :retrieve_balance, :no_bits_balance, _} = result
+      assert_audit_event("bits.credit_apply_failed")
     end
   end
 

--- a/test/stream_closed_captioner_phoenix_web/controllers/user_settings_controller_test.exs
+++ b/test/stream_closed_captioner_phoenix_web/controllers/user_settings_controller_test.exs
@@ -47,14 +47,16 @@ defmodule StreamClosedCaptionerPhoenixWeb.UserSettingsControllerTest do
 
     test "does not update password on invalid data", %{conn: conn} do
       old_password_conn =
-        put(conn, ~p"/users/settings", %{
-          "action" => "update_password",
-          "current_password" => "invalid",
-          "user" => %{
-            "password" => "has 6",
-            "password_confirmation" => "does not match"
-          }
-        })
+        capture_audit_events(fn ->
+          put(conn, ~p"/users/settings", %{
+            "action" => "update_password",
+            "current_password" => "invalid",
+            "user" => %{
+              "password" => "has 6",
+              "password_confirmation" => "does not match"
+            }
+          })
+        end)
 
       response = html_response(old_password_conn, 200)
       assert response =~ "Settings</h1>"
@@ -63,6 +65,7 @@ defmodule StreamClosedCaptionerPhoenixWeb.UserSettingsControllerTest do
       assert response =~ "is not valid"
 
       assert get_session(old_password_conn, :user_token) == get_session(conn, :user_token)
+      assert_audit_event("user_settings.password_change_failed")
     end
   end
 
@@ -90,29 +93,35 @@ defmodule StreamClosedCaptionerPhoenixWeb.UserSettingsControllerTest do
 
     test "updates the user email", %{conn: conn, user: user} do
       conn =
-        put(conn, ~p"/users/settings", %{
-          "action" => "update_email",
-          "current_password" => valid_user_password(),
-          "user" => %{"email" => unique_user_email()}
-        })
+        capture_audit_events(fn ->
+          put(conn, ~p"/users/settings", %{
+            "action" => "update_email",
+            "current_password" => valid_user_password(),
+            "user" => %{"email" => unique_user_email()}
+          })
+        end)
 
       assert redirected_to(conn) == ~p"/users/settings"
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "A link to confirm your email"
       assert Accounts.get_user_by_email(user.email)
+      assert_audit_event("user_settings.email_update_requested")
     end
 
     test "does not update email on invalid data", %{conn: conn} do
       conn =
-        put(conn, ~p"/users/settings", %{
-          "action" => "update_email",
-          "current_password" => "invalid",
-          "user" => %{"email" => "with spaces"}
-        })
+        capture_audit_events(fn ->
+          put(conn, ~p"/users/settings", %{
+            "action" => "update_email",
+            "current_password" => "invalid",
+            "user" => %{"email" => "with spaces"}
+          })
+        end)
 
       response = html_response(conn, 200)
       assert response =~ "Settings</h1>"
       assert response =~ "must have the @ sign and no spaces"
       assert response =~ "is not valid"
+      assert_audit_event("user_settings.email_update_request_failed")
     end
   end
 

--- a/test/support/audit_helpers.ex
+++ b/test/support/audit_helpers.ex
@@ -39,4 +39,11 @@ defmodule StreamClosedCaptionerPhoenix.AuditHelpers do
   def assert_audit_event(event_name) do
     assert_receive {:audit_event, _measurements, %{event: ^event_name}}
   end
+
+  @doc """
+  Refutes that an audit event with the given `event_name` was received.
+  """
+  def refute_audit_event(event_name) do
+    refute_receive {:audit_event, _measurements, %{event: ^event_name}}
+  end
 end


### PR DESCRIPTION
## Summary

Raises audit-event test coverage per the analysis in #393, from 9/26 asserted events to 24/26 of the reachable ones, plus a first dedicated unit-test suite for `AuditLog` itself. This is a **test-only** change — no `lib/` files were modified. New/edited files:

- `test/stream_closed_captioner_phoenix/audit_log_test.exs` (new) — unit tests for `redact_deep/1` (exercised via `info/2`/`warn/2` + telemetry capture, since it's private) and all four `format_reason/1` clauses.
- `test/support/audit_helpers.ex` — adds `refute_audit_event/1`, mirroring `assert_audit_event/1`.
- `test/stream_closed_captioner_phoenix/accounts_test.exs` — wraps `password_change_failed`, `password_reset_failed`, `password_reset_instructions_sent`; adds a new `remove_user_provider/1` success test for `oauth_unlinked`.
- `test/stream_closed_captioner_phoenix/accounts_oauth_test.exs` — wraps `account_registered`, `account_refreshed`; adds new tests for `account_register_failed` (uid unique-constraint collision), `account_link_failed` (missing required `username`/`login`), and `account_link_failed_email_conflict`.
- `test/stream_closed_captioner_phoenix/bits_test.exs` — adds `debit_created` alongside the existing `translation_activated` assertion; wraps `debit_create_failed` and `credit_apply_failed`.
- `test/stream_closed_captioner_phoenix_web/controllers/user_settings_controller_test.exs` — wraps `email_update_requested`, `email_update_request_failed`, `password_change_failed`.

Closes #393

## Implementation notes

- **24/26, not 26/26 — by design, confirmed with the repo owner (issue comment).** `accounts.oauth_unlink_failed` and `user_settings.provider_unlink_failed` have no reachable failure branch in the current implementation: `User.remove_provider/2` only does unconditional `cast/change` calls with zero validations, so `Repo.update/2` can't return `{:error, _}` short of a live DB failure. Rather than inventing a synthetic trigger or adding a production validation seam (out of scope for a test-only issue), these two are left undocumented-by-test and called out here as a known, accepted gap.
- **Discovered latent bug, not fixed here (out of scope):** passing a struct as a nested `AuditLog` metadata value currently **crashes** with `Protocol.UndefinedError`, because `redact_deep/1`'s map clause calls `Map.new/2`, which (as of recent Elixir versions) no longer treats structs as plain enumerable maps. No current `AuditLog.info/2`/`warn/2` call site passes a struct, so this isn't reachable in production today — but it's a real crash risk if one ever does. Locked in as an explicit regression test (`assert_raise Protocol.UndefinedError`) in `audit_log_test.exs` rather than silently asserting it "just works," since fixing `AuditLog` itself is outside this issue's test-only scope. Worth a follow-up issue.
- **Correction to the original plan's assumption about keyword-list redaction:** the plan described keyword-list entries as being *masked* (key kept, value replaced with `"[REDACTED]"`), matching the behavior for bare 2-tuples in non-keyword lists. Reading `redact_deep/1` shows keyword-list entries are actually *deleted* entirely (same as flat-map keys) — only the bare-2-tuple-in-a-non-keyword-list path does value-masking. Tests assert the real behavior for both cases.

## Test coverage

- `AuditLog.redact_deep/1`: flat map (string keys, atom keys, both for the same field), nested maps, keyword lists (deletion), non-keyword tuple lists (masking), non-key-value tuples/lists (no crash), non-sensitive values (including a value that equals a redacted key name), near-miss keys (exact-match only), empty map/list, and the struct-crash regression above.
- `AuditLog.format_reason/1`: all four clauses — atom (including `nil`/booleans), `%Ecto.Changeset{}` (via `traverse_errors/2`), binary, and the `inspect/2` catch-all.
- 6 new/wrapped integration tests across `accounts.ex`, `accounts_oauth.ex`, `bits/debit.ex`, `bits/transaction.ex`, and `user_settings_controller.ex`, each asserting the audit event fires on the exercised success/failure branch.

Coverage on the touched production modules (via `mix coveralls`): `audit_log.ex` 100%, `accounts_oauth.ex` 100%, `accounts.ex` 91.9%, `bits/debit.ex` 95.3%, `bits/transaction.ex` 95.3%, `user_settings_controller.ex` 90.3% (remaining gaps are the two known-unreachable branches above plus a few pre-existing lines unrelated to this issue).

Full suite: 5 doctests, 474 tests, 0 failures. `mix lint` (Credo) and `mix security` (Sobelow) report only pre-existing findings in untouched `lib/` files — zero new violations from this diff.

## Open questions resolved

Both open questions from the implementation plan were resolved by the repo owner in an issue comment before implementation started:
1. Land at 24/26 reachable events; document the 2 unreachable branches as a known/accepted gap (option A) rather than adding a production validation seam.
2. Yes — this PR description frames results as "24/26 reachable" rather than claiming the original report's "100%" framing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrUym2ZDPX1aqEw7gWoCFz)_